### PR TITLE
Release v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,13 +3,37 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.7",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -28,6 +52,15 @@ name = "anstyle-parse"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -305,7 +338,7 @@ version = "4.5.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a4c05b9e80c5ccd3a7ef080ad7b6ba7d6fc00a985b8b157197075677c82c7a0"
 dependencies = [
- "anstream",
+ "anstream 0.6.21",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -355,6 +388,29 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "env_filter"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+dependencies = [
+ "anstream 1.0.0",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
 
 [[package]]
 name = "errno"
@@ -550,6 +606,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jiff"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,9 +662,9 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 dependencies = [
  "value-bag",
 ]
@@ -662,6 +742,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "presenceforge"
 version = "0.1.0"
 dependencies = [
@@ -671,8 +766,10 @@ dependencies = [
  "bytes",
  "clap",
  "dotenvy",
+ "env_logger",
  "futures",
  "libc",
+ "log",
  "serde",
  "serde_json",
  "smol",
@@ -704,6 +801,35 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustix"
@@ -914,9 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "presenceforge"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-std",
  "blocking",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ byteorder = "1"
 bytes = "1"
 uuid = { version = "1", features = ["v4"] }
 futures = { version = "0.3", optional = true }
+log = "0.4"
 
 # Async runtime dependencies
 tokio = { version = "1", features = ["net", "io-util", "fs", "rt", "rt-multi-thread", "time", "macros"], optional = true }
@@ -33,6 +34,7 @@ blocking = { version = "1", optional = true }
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }
 dotenvy = "0.15"
+env_logger = "0.11"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -79,3 +81,7 @@ required-features = ["smol-runtime"]
 [[example]]
 name = "async_tokio_reconnect"
 required-features = ["tokio-runtime"]
+
+[[example]]
+name = "event_listener"
+required-features = ["secrets"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presenceforge"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Sreehari Anil <sreehari7102008@gmail.com>"]
 description = "A library for Discord Rich Presence (IPC) integration"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Rust library for Discord Rich Presence that actually works without the headach
 [![Rust](https://img.shields.io/badge/rust-1.70+-blue.svg)](https://www.rust-lang.org)
 ![Crates.io Version](https://img.shields.io/crates/v/presenceforge)
 
-> **Note**: This is currently in development (v0.1.0). Things might break.
+> **Note**: This is currently in development (v0.2.0). Things might break.
 > This is a learning/hobby project.
 > Features and APIs may change in future versions.
 
@@ -34,6 +34,7 @@ A Rust library for Discord Rich Presence that actually works without the headach
 - [x] Async support with runtime-agnostic design
 - [x] Support for tokio, async-std, and smol
 - [x] Flexible pipe/socket selection
+- [x] IPC Event System (subscribe, unsubscribe, event polling)
 
 ## Quick Start
 
@@ -41,14 +42,14 @@ Add PresenceForge to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-presenceforge = "0.1.0"
+presenceforge = "0.2.0"
 ```
 
 For async support, add one of the runtime features:
 
 ```toml
 [dependencies]
-presenceforge = { version = "0.1.0", features = ["tokio-runtime"] }
+presenceforge = { version = "0.2.0", features = ["tokio-runtime"] }
 # OR
 presenceforge = { version = "0.1.0", features = ["async-std-runtime"] }
 # OR
@@ -224,6 +225,10 @@ cargo run --example basic
 - `client.is_connected()` - Check if the handshake succeeded
 - `client.set_activity(activity)` - Set Rich Presence activity
 - `client.clear_activity()` - Clear current activity
+- `client.subscribe(event, args)` - Subscribe to IPC events (e.g., "READY", "ERROR")
+- `client.unsubscribe(event, args)` - Unsubscribe from events
+- `client.next_event()` - Block until the next event is received
+- `client.poll_event()` - Check for events without blocking
 
 ### Activity Builder
 
@@ -241,7 +246,9 @@ ActivityBuilder::new()
     .small_image("image_key")        // Small image asset
     .small_text("Hover text")        // Small image hover text
     .button("Label", "https://url")  // Clickable button (max 2)
-    .party("id",1, 4)               // Party size (current, max)
+    .party("id", 1, 4)               // Party size with custom ID
+    .party_simple(1, 4)              // Party size with auto-generated ID
+    .end_timestamp_from_now(dur)     // End time relative to now
     .build()
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ use presenceforge::sync::DiscordIpcClient;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut client = DiscordIpcClient::new("your_client_id")?;
     client.connect()?;
+    // Optional sanity check if your setup is more complex
+    debug_assert!(client.is_connected(), "Discord handshake failed");
 
     let activity = ActivityBuilder::new()
         .state("Playing a game")
@@ -91,6 +93,7 @@ use presenceforge::{AsyncDiscordIpcClient, ActivityBuilder, Result};
 async fn main() -> Result {
     let mut client = AsyncDiscordIpcClient::new("your_client_id").await?;
     client.connect().await?;
+    debug_assert!(client.is_connected(), "Discord handshake failed");
 
     let activity = ActivityBuilder::new()
         .state("Playing a game")
@@ -119,6 +122,7 @@ use std::time::Duration;
 async fn main() -> Result {
     let mut client = AsyncDiscordIpcClient::new("your_client_id").await?;
     client.connect().await?;
+    debug_assert!(client.is_connected(), "Discord handshake failed");
 
     let activity = ActivityBuilder::new()
         .state("Playing a game")
@@ -146,6 +150,7 @@ fn main() -> Result {
     smol::block_on(async {
         let mut client = AsyncDiscordIpcClient::new("your_client_id").await?;
         client.connect().await?;
+    debug_assert!(client.is_connected(), "Discord handshake failed");
 
         let activity = ActivityBuilder::new()
             .state("Playing a game")
@@ -163,7 +168,6 @@ fn main() -> Result {
     })
 }
 ```
-
 
 ## Getting Your Discord Application ID
 
@@ -217,6 +221,7 @@ cargo run --example basic
 
 - `DiscordIpcClient::new(client_id)` - Create a new client
 - `client.connect()` - Connect to Discord
+- `client.is_connected()` - Check if the handshake succeeded
 - `client.set_activity(activity)` - Set Rich Presence activity
 - `client.clear_activity()` - Clear current activity
 

--- a/changelogs/0.2.0.md
+++ b/changelogs/0.2.0.md
@@ -1,0 +1,67 @@
+
+## [0.2.0] - release
+
+### Added
+
+#### IPC Event System
+
+- Event subscription API for both sync and async clients:
+  - `subscribe(event, args)`
+  - `unsubscribe(event, args)`
+  - `next_event()`
+  - `poll_event()` (sync)
+- Typed event models in protocol parsing:
+  - `ReadyEvent`
+  - `ActivityJoinEvent`
+  - `ActivitySpectateEvent`
+  - `ActivityJoinRequestEvent`
+  - `ErrorEvent`
+  - `EventData` enum variants for all supported event payloads
+- New example: `examples/event_listener.rs`
+- New example: `examples/ready_event.rs`
+
+#### Discovery Improvements
+
+- New IPC discovery module: `src/ipc/discovery.rs`
+- Shared discovery helpers used across sync and async runtimes
+- Improved Unix path discovery coverage (XDG runtime, Flatpak paths, Snap-style directories, `/run/user/{uid}` fallback)
+
+#### Activity Builder Additions
+
+- `end_timestamp_from_now(Duration)`
+- `party_simple(current_size, max_size)` with auto-generated party ID
+
+### Changed
+
+#### Error Model (Breaking)
+
+- Refactored major `DiscordIpcError` string-based paths to typed reason models.
+- Added and exposed typed error kinds:
+  - `HandshakeFailureKind`
+  - `InvalidResponseKind`
+  - `ProtocolViolationKind`
+  - `InvalidActivityKind`
+- Added typed constructors for common error creation paths.
+- `Activity::validate()` now returns typed `ActivityValidationError` instead of raw string reasons.
+
+#### IPC Message Model
+
+- `IpcMessage` now includes optional `evt` field for event subscribe/unsubscribe frames.
+
+#### Async Runtime Implementations
+
+- Runtime wrappers (`tokio`, `async-std`, `smol`) updated to expose event APIs.
+- Async runtime connection code paths now share centralized IPC discovery.
+
+#### Logging
+
+- Debug macro behavior migrated to `log` crate backend while preserving env-gated behavior via `PRESENCEFORGE_DEBUG`.
+
+
+### Testing
+
+- Added/updated integration coverage for:
+  - typed READY event parsing
+  - typed error categories and constructors
+  - retry behavior with typed invalid activity paths
+- Expanded protocol tests for newly supported event payloads.

--- a/docs/ACTIVITY_BUILDER_REFERENCE.md
+++ b/docs/ACTIVITY_BUILDER_REFERENCE.md
@@ -115,6 +115,17 @@ S = Small Image (overlays large image in bottom-right corner)
 - **Use for:** Match end times, timer events, scheduled activities
 - **Note:** If both start and end are set, Discord shows remaining time
 
+#### End Timestamp From Now
+
+```rust
+use std::time::Duration;
+
+.end_timestamp_from_now(Duration::from_secs(600))? // 10 minutes from now
+```
+
+- **Returns:** `Result<Self>`
+- **Use for:** Easily setting a countdown without manual timestamp math
+
 **Getting Unix timestamp:**
 
 ```rust
@@ -150,6 +161,15 @@ let end_time = now + 300;
   - "2 of 4" (2 players in a 4-player game)
   - "5 of 10" (5 people in a 10-person voice channel)
 
+#### Simple Party (`party_simple()`)
+
+```rust
+.party_simple(2, 4) // current_size, max_size
+```
+
+- **Effect:** Automatically generates a unique UUID for the party ID.
+- **Use for:** Quick multiplayer status where you don't need to track specific party IDs.
+
 ---
 
 ### 7. **Buttons** (`button()`)
@@ -174,7 +194,7 @@ let end_time = now + 300;
 ### 8. **Secrets** (For "Ask to Join" and Spectate features)
 
 > **⚠️ Feature Flag Required:** These methods require the `secrets` feature flag to be enabled.
-> Add to your `Cargo.toml`: `presenceforge = { version = "0.1.0", features = ["secrets"] }`
+> Add to your `Cargo.toml`: `presenceforge = { version = "0.2.0", features = ["secrets"] }`
 
 #### Note: untested feature
 
@@ -254,9 +274,10 @@ let activity = ActivityBuilder::new()
 
     // Time
     .start_timestamp_now()?
+    .end_timestamp_from_now(std::time::Duration::from_secs(3600))?
 
     // Party
-    .party("party-12345", 3, 4)
+    .party_simple(3, 4)
 
     // Buttons
     .button("🎮 Join Game", "https://game.example.com/join")

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -2,7 +2,7 @@
 
 API reference for PresenceForge (work-in-progress; APIs may change).
 
-> **Note:** PresenceForge v0.1.0 is an early development release.  
+> **Note:** PresenceForge v0.2.0 is an early development release.  
 > It’s functional, but features may change or be incomplete.
 
 ## Table of Contents
@@ -12,6 +12,7 @@ API reference for PresenceForge (work-in-progress; APIs may change).
 - [Activity](#activity)
 - [PipeConfig](#pipeconfig)
 - [IpcConnection](#ipcconnection)
+- [Event Subscription](#event-subscription)
 - [Error Types](#error-types)
 - [Async Clients](#async-clients)
 
@@ -155,6 +156,54 @@ let _resp = client.clear_activity()?;
 **Returns:** `Result<serde_json::Value, DiscordIpcError>`
 
 **Note:** This removes the Rich Presence from your profile entirely.
+
+---
+
+## Event Subscription
+
+PresenceForge supports subscribing to Discord IPC events like `READY`, `ACTIVITY_JOIN`, etc.
+
+### `subscribe(&mut self, event: impl Into<String>, args: serde_json::Value) -> Result<()>`
+
+Subscribes to a specific Discord IPC event.
+
+```rust
+use serde_json::json;
+
+client.subscribe("ACTIVITY_JOIN", json!({}))?;
+```
+
+---
+
+### `unsubscribe(&mut self, event: impl Into<String>, args: serde_json::Value) -> Result<()>`
+
+Unsubscribes from a previously subscribed event.
+
+```rust
+client.unsubscribe("ACTIVITY_JOIN", json!({}))?;
+```
+
+---
+
+### `next_event(&mut self) -> Result<EventData>`
+
+Blocks until the next event is received from Discord.
+
+```rust
+use presenceforge::EventData;
+
+match client.next_event()? {
+    EventData::Ready(ready) => println!("Discord is ready!"),
+    EventData::ActivityJoin(join) => println!("User joined via secret: {}", join.secret),
+    _ => {}
+}
+```
+
+---
+
+### `poll_event(&mut self) -> Result<Option<EventData>>`
+
+Checks for a queued event without blocking. Returns `Ok(None)` if no event is available.
 
 ---
 
@@ -538,34 +587,41 @@ Main error type for Discord IPC operations.
 
 ```rust
 pub enum DiscordIpcError {
-    ConnectionFailed(String),
-    ProtocolError(String),
-    SerializationError(String),
-    InvalidClientId,
-    NotConnected,
-    IoError(std::io::Error),
-    // ... other variants
+    ConnectionFailed(io::Error),
+    SocketDiscoveryFailed { source: io::Error, attempted_paths: Vec<String> },
+    ConnectionTimeout { timeout_ms: u64, last_error: Option<String> },
+    NoValidSocket,
+    SerializationFailed(serde_json::Error),
+    DeserializationFailed(serde_json::Error),
+    InvalidResponse { kind: InvalidResponseKind, details: ErrorDetail },
+    HandshakeFailed { kind: HandshakeFailureKind, details: ErrorDetail },
+    SocketClosed,
+    InvalidOpcode(u32),
+    ProtocolViolation { kind: ProtocolViolationKind, details: ErrorDetail, context: ProtocolContext },
+    DiscordError { code: i32, message: String },
+    InvalidActivity(ActivityValidationError),
+    SystemTimeError(SystemTimeError),
 }
 ```
 
 ### Common Errors
 
-#### `ConnectionFailed(String)`
+#### `ConnectionFailed(std::io::Error)`
 
-Failed to connect to Discord.
+Failed to connect to Discord IPC socket or pipe.
 
 **Common causes:**
 
 - Discord is not running
-- No Discord pipes available
-- Permission issues with IPC socket/pipe
+- No available IPC pipes/sockets
+- Permission denied accessing pipe/socket
 
 **Example:**
 
 ```rust
 match DiscordIpcClient::new("client_id") {
-    Err(DiscordIpcError::ConnectionFailed(msg)) => {
-        eprintln!("Connection failed: {}. Is Discord running?", msg);
+    Err(DiscordIpcError::ConnectionFailed(e)) => {
+        eprintln!("Connection failed: {}. Is Discord running?", e);
     }
     Ok(client) => { /* ... */ }
     Err(e) => eprintln!("Other error: {}", e),
@@ -574,35 +630,44 @@ match DiscordIpcClient::new("client_id") {
 
 ---
 
-#### `ProtocolError(String)`
+#### `HandshakeFailed { kind, details }`
 
-Discord IPC protocol error.
-
-**Common causes:**
-
-- Invalid response from Discord
-- Protocol version mismatch
-- Corrupted data
-
----
-
-#### `SerializationError(String)`
-
-Failed to serialize/deserialize JSON data.
+Handshake with Discord failed.
 
 **Common causes:**
 
-- Invalid activity structure
-- Missing required fields
-- Type mismatches
+- Invalid error payload from Discord
+- Unexpected opcode during handshake
 
 ---
 
-#### `InvalidClientId`
+#### `ProtocolViolation { kind, details, context }`
 
-The provided client ID is invalid.
+A violation of the Discord IPC protocol occurred.
 
-**Solution:** Verify your Application ID from Discord Developer Portal.
+**Common causes:**
+
+- Received an invalid opcode value
+- Payload size exceeds maximum limit
+
+---
+
+#### `SerializationFailed(serde_json::Error)` and `DeserializationFailed(serde_json::Error)`
+
+Failed to encode or decode JSON data.
+
+**Common causes:**
+
+- Invalid activity structure (e.g., button URL missing protocol)
+- Malformed response from Discord
+
+---
+
+#### `NoValidSocket`
+
+No valid Discord IPC sockets were found on the system.
+
+**Solution:** Ensure Discord is running and not restricted by a sandbox or firewall.
 
 ---
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -94,6 +94,24 @@ let _handshake = client.connect()?; // JSON handshake payload
 
 ---
 
+#### `is_connected(&self) -> bool`
+
+Returns `true` after a successful handshake and `false` otherwise.
+
+```rust
+if !client.is_connected() {
+    // Guard against logic bugs where `connect()` was skipped
+    anyhow::bail!("Discord client is not connected");
+}
+```
+
+**Notes:**
+
+- Automatically resets to `false` when the underlying connection closes or before the next handshake attempt.
+- Useful for sanity checks in larger applications where the connect step might be conditional.
+
+---
+
 // (No sync reconnect method)
 // If the connection is lost, recreate the client and call connect() again.
 
@@ -654,6 +672,8 @@ if error.is_recoverable() {
 ## Async Clients
 
 Async versions of the IPC client for different runtimes.
+
+All async variants expose the same surface as `AsyncDiscordIpcClient`, including `is_connected()` for sanity checks between awaits.
 
 ### Tokio
 

--- a/docs/ASYNC_RUNTIMES.md
+++ b/docs/ASYNC_RUNTIMES.md
@@ -84,7 +84,6 @@ async fn setup_presence() -> Result {
     // Connect to Discord
     client.connect().await?;
     debug_assert!(client.is_connected(), "Discord handshake failed");
-    debug_assert!(client.is_connected(), "Discord handshake failed");
 
     println!("Connected to Discord!");
 

--- a/docs/ASYNC_RUNTIMES.md
+++ b/docs/ASYNC_RUNTIMES.md
@@ -83,6 +83,8 @@ async fn setup_presence() -> Result {
 
     // Connect to Discord
     client.connect().await?;
+    debug_assert!(client.is_connected(), "Discord handshake failed");
+    debug_assert!(client.is_connected(), "Discord handshake failed");
 
     println!("Connected to Discord!");
 
@@ -156,6 +158,7 @@ async fn main() -> Result {
 
     // Connect to Discord
     client.connect().await?;
+    debug_assert!(client.is_connected(), "Discord handshake failed");
 
     println!("Connected to Discord!");
 
@@ -336,6 +339,7 @@ async fn main() -> Result {
     // Create and connect client
     let mut client = AsyncDiscordIpcClient::new("your_client_id").await?;
     client.connect().await?;
+    debug_assert!(client.is_connected(), "Discord handshake failed");
 
     println!("Connected to Discord!");
 
@@ -435,6 +439,7 @@ fn main() -> Result {
         // Create and connect client
         let mut client = AsyncDiscordIpcClient::new("your_client_id").await?;
         client.connect().await?;
+        debug_assert!(client.is_connected(), "Discord handshake failed");
 
         println!("Connected to Discord!");
 

--- a/docs/ASYNC_RUNTIMES.md
+++ b/docs/ASYNC_RUNTIMES.md
@@ -1,6 +1,6 @@
 # Async Runtimes Guide
 
-> **Note:** PresenceForge v0.1.0 is an early development release.  
+> **Note:** PresenceForge v0.2.0 is an early development release.  
 > It’s functional, but features may change or be incomplete.
 
 ## Table of Contents
@@ -63,13 +63,13 @@ Add to your `Cargo.toml` with **one** of these feature flags:
 ```toml
 [dependencies]
 # For Tokio
-presenceforge = { version = "0.1.0", features = ["tokio-runtime"] }
+presenceforge = { version = "0.2.0", features = ["tokio-runtime"] }
 
 # For async-std
-presenceforge = { version = "0.1.0", features = ["async-std-runtime"] }
+presenceforge = { version = "0.2.0", features = ["async-std-runtime"] }
 
 # For smol
-presenceforge = { version = "0.1.0", features = ["smol-runtime"] }
+presenceforge = { version = "0.2.0", features = ["smol-runtime"] }
 ```
 
 **This exact code works with all three runtimes:**
@@ -142,7 +142,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-presenceforge = { version = "0.1.0", features = ["tokio-runtime"] }
+presenceforge = { version = "0.2.0", features = ["tokio-runtime"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 
@@ -323,7 +323,7 @@ async-std provides an async API similar to the standard library.
 
 ```toml
 [dependencies]
-presenceforge = { version = "0.1.0", features = ["async-std-runtime"] }
+presenceforge = { version = "0.2.0", features = ["async-std-runtime"] }
 async-std = { version = "1", features = ["attributes"] }
 ```
 
@@ -423,7 +423,7 @@ smol is a small and fast async runtime.
 
 ```toml
 [dependencies]
-presenceforge = { version = "0.1.0", features = ["smol-runtime"] }
+presenceforge = { version = "0.2.0", features = ["smol-runtime"] }
 smol = "2"
 ```
 

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -87,15 +87,19 @@ No Discord IPC sockets were found.
 
 ---
 
-### `HandshakeFailed(String)`
+### `HandshakeFailed { kind, details }`
 
 Discord responded with an error or an unexpected opcode during the handshake.
 
 ```rust
+use presenceforge::HandshakeFailureKind;
+
 match client.connect() {
     Ok(_) => println!("Handshake successful"),
-    Err(DiscordIpcError::HandshakeFailed(msg)) => {
-        eprintln!("Handshake failed: {}", msg);
+    Err(DiscordIpcError::HandshakeFailed { kind, details }) => {
+        if matches!(kind, HandshakeFailureKind::UnexpectedOpcode) {
+            eprintln!("Handshake opcode mismatch: {}", details);
+        }
     }
     Err(e) => eprintln!("Other error: {}", e),
 }
@@ -103,7 +107,7 @@ match client.connect() {
 
 ---
 
-### `ProtocolViolation { message, context }` and `InvalidOpcode(u32)`
+### `ProtocolViolation { kind, details, context }` and `InvalidOpcode(u32)`
 
 Indicates malformed data or unexpected protocol values. The `context` includes opcode and payload size when available.
 
@@ -121,7 +125,7 @@ if let Err(DiscordIpcError::SerializationFailed(e)) = client.set_activity(&activ
 
 ---
 
-### `InvalidResponse(String)`
+### `InvalidResponse { kind, details }`
 
 Response shape was valid JSON but not what the library expected (e.g., nonce mismatch).
 
@@ -139,7 +143,7 @@ The underlying connection closed while reading/writing.
 
 ---
 
-### `InvalidActivity(String)` and `SystemTimeError(String)`
+### `InvalidActivity { kind, details }` and `SystemTimeError(String)`
 
 Activity validation failed, or system time issues occurred while computing timestamps.
 

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -252,10 +252,12 @@ fn maintain_presence(mut client: DiscordIpcClient) -> Result<(), Box<dyn std::er
                 println!(" Activity updated");
             }
             Err(e) if e.is_connection_error() => {
-                eprintln!(" Connection lost. Recreating client and reconnecting...");
-                // Recreate the client (sync API has no reconnect method)
-                client = DiscordIpcClient::new("your_client_id")?;
-                let _ = client.connect()?;
+                eprintln!(" Connection lost. Reconnecting...");
+                // Use the built-in reconnect() method
+                if let Err(reconnect_err) = client.reconnect() {
+                    eprintln!(" Failed to reconnect: {}", reconnect_err);
+                    return Err(reconnect_err.into());
+                }
                 client.set_activity(&activity)?;
             }
             Err(e) => {

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -52,11 +52,11 @@ git ls-remote git@github.com:Sreehari425/presenceforge.git
 
 If SSH works but you still have issues, please report them on GitHub Issues.
 
-For now, use version `0.1.0` instead:
+For now, use version `0.2.0` instead:
 
 ```toml
 [dependencies]
-presenceforge = "0.1.0"
+presenceforge = "0.2.0"
 ```
 
 ---
@@ -74,7 +74,7 @@ The feature is called `tokio-runtime`, not `tokio`:
 
 ```toml
 [dependencies]
-presenceforge = { version = "0.1.0", features = ["tokio-runtime"] }
+presenceforge = { version = "0.2.0", features = ["tokio-runtime"] }
 ```
 
 Valid features: `tokio-runtime`, `async-std-runtime`, `smol-runtime`
@@ -94,7 +94,7 @@ Make sure you're using compatible versions:
 
 ```toml
 [dependencies]
-presenceforge = { version = "0.1.0", features = ["tokio-runtime"] }
+presenceforge = { version = "0.2.0", features = ["tokio-runtime"] }
 tokio = { version = "1", features = ["full"] }  # Use version 1.x
 ```
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -131,6 +131,9 @@ let mut client = DiscordIpcClient::new(client_id)?;
 
 // 2. Connect to Discord (this performs the handshake)
 client.connect()?;
+// Optional sanity check to catch missed connect paths in bigger apps
+debug_assert!(client.is_connected(), "Handshake did not complete");
+assert!(client.is_connected(), "Handshake did not complete");
 
 // 3. Build your activity with the builder pattern
 let activity = ActivityBuilder::new()

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -2,7 +2,7 @@
 
 Welcome to PresenceForge! This guide will help you get started with integrating Discord Rich Presence into your Rust application.
 
-> **Note:** PresenceForge v0.1.0 is an early development release.  
+> **Note:** PresenceForge v0.2.0 is an early development release.  
 > It’s functional, but features may change or be incomplete.
 
 ## What is Discord Rich Presence?
@@ -36,7 +36,7 @@ Add PresenceForge to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-presenceforge = "0.1.0"
+presenceforge = "0.2.0"
 ```
 
 ### With Async Support
@@ -46,13 +46,13 @@ If you need async support, add one of the runtime features:
 ```toml
 [dependencies]
 # For Tokio users
-presenceforge = { version = "0.1.0", features = ["tokio-runtime"] }
+presenceforge = { version = "0.2.0", features = ["tokio-runtime"] }
 
 # For async-std users
-presenceforge = { version = "0.1.0", features = ["async-std-runtime"] }
+presenceforge = { version = "0.2.0", features = ["async-std-runtime"] }
 
 # For smol users
-presenceforge = { version = "0.1.0", features = ["smol-runtime"] }
+presenceforge = { version = "0.2.0", features = ["smol-runtime"] }
 ```
 
 ## Your First Rich Presence
@@ -70,7 +70,7 @@ cd my-discord-presence
 
 ```toml
 [dependencies]
-presenceforge = "0.1.0"
+presenceforge = "0.2.0"
 ```
 
 ### Step 3: Write your first presence

--- a/examples/README.md
+++ b/examples/README.md
@@ -77,6 +77,12 @@ cargo run --example update_activity_tokio --features tokio-runtime -- --client-i
 
 # Flatpak Discord - Connect to Flatpak Discord using custom path configuration
 cargo run --example flatpak_discord -- --client-id YOUR_CLIENT_ID
+
+# Event Listener - Demonstrates IPC Event System (subscribe, unsubscribe, poll_event)
+cargo run --example event_listener -- --client-id YOUR_CLIENT_ID
+
+# Ready Event - Demonstrates connect_with_ready() and user data parsing
+cargo run --example ready_event -- --client-id YOUR_CLIENT_ID
 ```
 
 ## Examples Overview
@@ -94,7 +100,6 @@ Simple example showing:
 
 **Complete ActivityBuilder documentation example** showing:
 
-- Note all methods at the time of writing dosent work
 - **Every single builder method** with detailed explanations
 - **Visual layout guide** showing where each field appears in Discord
 - **Practical tips** for each option (images, timestamps, party, buttons, secrets)
@@ -225,6 +230,24 @@ Flatpak Discord example showing:
 - Step-by-step guide with detailed output
 
 **Note:** This example works with both Flatpak and standard Discord. It automatically detects which version is available.
+
+### `event_listener.rs`
+
+Demonstrates the Discord IPC Event System:
+
+- Subscribing to events (`ACTIVITY_JOIN`, `READY`, etc.)
+- Using `next_event()` to wait for events synchronously
+- Using `poll_event()` to check for events without blocking
+- Unsubscribing from events
+- Handling event data variants (`EventData`)
+
+### `ready_event.rs`
+
+Shows how to retrieve initial connection data:
+
+- Using `connect_with_ready()` to perform handshake and get READY payload
+- Accessing authenticated user information (username, ID, avatar)
+- Graceful connection closing
 
 ## Prerequisites
 

--- a/examples/async_smol.rs
+++ b/examples/async_smol.rs
@@ -30,7 +30,6 @@ fn main() -> Result {
 
     smol::block_on(async {
         let mut client = AsyncDiscordIpcClient::new(&client_id).await?;
-
         // Perform handshake
         client.connect().await?;
 

--- a/examples/builder_all.rs
+++ b/examples/builder_all.rs
@@ -69,6 +69,8 @@ fn main() -> Result {
         // Note: If you set both start and end, Discord shows remaining time
         // Uncomment to try:
         // .end_timestamp(SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() + 300)
+        // Or use the convenience method:
+        .end_timestamp_from_now(Duration::from_secs(300))?
         // ═══════════════════════════════════════════════════════════
         // IMAGES (Large and Small)
         // ═══════════════════════════════════════════════════════════
@@ -89,7 +91,9 @@ fn main() -> Result {
         // Party: Shows "X of Y" (e.g., "2 of 4" for a party)
         // Useful for multiplayer games showing current players
         // Parameters: party_id, current_size, max_size
-        .party("party-12345", 2, 4)
+        // .party("party-12345", 2, 4)
+        // Or use the simple party method which generates a unique ID:
+        .party_simple(2, 4)
         // NOTE : BUTTONS and SECRETS are mutually exclusive. We add buttons
         // only when the `secrets` feature is NOT enabled so the example
         // remains valid in both configurations.
@@ -139,12 +143,12 @@ fn main() -> Result {
     println!("   • State: 'Playing a custom game'");
     println!("   • Large image with tooltip");
     println!("   • Small image (Rust logo) in corner");
-    println!("   • Party info: '2 of 4'");
+    println!("   • Party info: '2 of 4' (with auto-generated ID)");
     #[cfg(not(feature = "secrets"))]
     println!("   • Two clickable buttons");
     #[cfg(feature = "secrets")]
     println!("   • Join/spectate/match secrets enabled (ask-to-join)");
-    println!("   • Elapsed time counter");
+    println!("   • Time counter (elapsed AND remaining)");
 
     // Keep activity visible for 30 seconds
     println!("\nKeeping activity visible for 30 seconds...");

--- a/examples/event_listener.rs
+++ b/examples/event_listener.rs
@@ -70,7 +70,7 @@ fn main() -> Result {
                 break;
             }
         }
-        
+
         // Small sleep to avoid hogging CPU in this example loop
         std::thread::sleep(Duration::from_millis(100));
     }

--- a/examples/event_listener.rs
+++ b/examples/event_listener.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2025-2026 Sreehari Anil and project contributors
+
 use clap::Parser;
 use presenceforge::sync::DiscordIpcClient;
 use presenceforge::{ActivityBuilder, EventData, Result};

--- a/examples/event_listener.rs
+++ b/examples/event_listener.rs
@@ -49,6 +49,13 @@ fn main() -> Result {
     // Note: Discord requires us to subscribe to receive these events
     client.subscribe("ACTIVITY_JOIN", serde_json::json!({}))?;
     println!("✓ Subscribed to ACTIVITY_JOIN event.");
+    println!("✓ You can also check for events without blocking using client.poll_event().");
+
+    // Check once without blocking
+    match client.poll_event()? {
+        Some(_) => println!("! Found an early event!"),
+        None => println!("✓ No immediate events (as expected)."),
+    }
 
     println!("\n--- Waiting for events (Ctrl+C to stop) ---");
     println!("If someone clicks 'Join' on your profile in Discord, you'll see an event here.");
@@ -76,7 +83,15 @@ fn main() -> Result {
 
         // Small sleep to avoid hogging CPU in this example loop
         std::thread::sleep(Duration::from_millis(100));
+
+        // In a real app, you might break based on some condition:
+        // break;
     }
+
+    // This code would be reached if the loop above breaks
+    println!("\nUnsubscribing from events...");
+    client.unsubscribe("ACTIVITY_JOIN", serde_json::json!({}))?;
+    println!("✓ Unsubscribed.");
 
     Ok(())
 }

--- a/examples/event_listener.rs
+++ b/examples/event_listener.rs
@@ -40,6 +40,7 @@ fn main() -> Result {
         .details("Waiting for someone to join...")
         .party_simple(1, 5)
         .join_secret("very_secret_join_token")
+        .instance(true)
         .build();
 
     client.set_activity(&activity)?;

--- a/examples/event_listener.rs
+++ b/examples/event_listener.rs
@@ -1,0 +1,79 @@
+use clap::Parser;
+use presenceforge::sync::DiscordIpcClient;
+use presenceforge::{ActivityBuilder, EventData, Result};
+use std::time::Duration;
+
+/// Demonstrate subscribing to and receiving Discord events.
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Discord Application Client ID
+    #[arg(short, long)]
+    client_id: Option<String>,
+}
+
+fn main() -> Result {
+    // Initialize logging so we can see what's happening
+    env_logger::init();
+
+    let _ = dotenvy::dotenv();
+    let args = Args::parse();
+
+    let client_id = args
+        .client_id
+        .or_else(|| std::env::var("DISCORD_CLIENT_ID").ok())
+        .unwrap_or_else(|| {
+            eprintln!("Error: DISCORD_CLIENT_ID is required!");
+            std::process::exit(1);
+        });
+
+    let mut client = DiscordIpcClient::new(client_id)?;
+    client.connect()?;
+    println!("✓ Connected to Discord!");
+
+    // Set an activity with a join secret to enable the "Join" button in Discord
+    let activity = ActivityBuilder::new()
+        .state("Testing Event System")
+        .details("Waiting for someone to join...")
+        .party_simple(1, 5)
+        .join_secret("very_secret_join_token")
+        .build();
+
+    client.set_activity(&activity)?;
+    println!("✓ Activity set with join secret.");
+
+    // Subscribe to ACTIVITY_JOIN event
+    // Note: Discord requires us to subscribe to receive these events
+    client.subscribe("ACTIVITY_JOIN", serde_json::json!({}))?;
+    println!("✓ Subscribed to ACTIVITY_JOIN event.");
+
+    println!("\n--- Waiting for events (Ctrl+C to stop) ---");
+    println!("If someone clicks 'Join' on your profile in Discord, you'll see an event here.");
+
+    // Listen for events in a loop
+    // In a real app, you might run this in a separate thread
+    loop {
+        match client.next_event() {
+            Ok(EventData::ActivityJoin(event)) => {
+                println!("\n RECEIVED EVENT: Someone wants to join!");
+                println!("   Secret: {}", event.secret);
+            }
+            Ok(EventData::Error(e)) => {
+                eprintln!("\n Discord Error: {} - {}", e.code, e.message);
+            }
+            Ok(EventData::Unknown { name, .. }) => {
+                println!("\n Received unknown event: {}", name);
+            }
+            Ok(_) => {} // Ignore other events like READY
+            Err(e) => {
+                eprintln!("\n Communication Error: {}", e);
+                break;
+            }
+        }
+        
+        // Small sleep to avoid hogging CPU in this example loop
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    Ok(())
+}

--- a/examples/ready_event.rs
+++ b/examples/ready_event.rs
@@ -1,4 +1,8 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2025-2026 Sreehari Anil and project contributors
+
 use clap::Parser;
+
 use presenceforge::sync::DiscordIpcClient;
 use presenceforge::Result;
 

--- a/examples/ready_event.rs
+++ b/examples/ready_event.rs
@@ -18,7 +18,7 @@ fn main() -> Result {
     let client_id = args
         .client_id
         .or_else(|| std::env::var("DISCORD_CLIENT_ID").ok())
-        .unwrap_or_else(|| {>
+        .unwrap_or_else(|| {
             eprintln!("Error: DISCORD_CLIENT_ID is required!");
             eprintln!("Provide it via:");
             eprintln!("  - Command line: cargo run --example ready_event -- --client-id YOUR_ID");

--- a/examples/ready_event.rs
+++ b/examples/ready_event.rs
@@ -1,0 +1,50 @@
+use clap::Parser;
+use presenceforge::sync::DiscordIpcClient;
+use presenceforge::Result;
+
+/// Fetch user info from Discord READY payload.
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Discord Application Client ID
+    #[arg(short, long)]
+    client_id: Option<String>,
+}
+
+fn main() -> Result {
+    let _ = dotenvy::dotenv();
+    let args = Args::parse();
+
+    let client_id = args
+        .client_id
+        .or_else(|| std::env::var("DISCORD_CLIENT_ID").ok())
+        .unwrap_or_else(|| {>
+            eprintln!("Error: DISCORD_CLIENT_ID is required!");
+            eprintln!("Provide it via:");
+            eprintln!("  - Command line: cargo run --example ready_event -- --client-id YOUR_ID");
+            eprintln!("  - Environment: DISCORD_CLIENT_ID=YOUR_ID cargo run --example ready_event");
+            std::process::exit(1);
+        });
+
+    let mut client = DiscordIpcClient::new(client_id)?;
+
+    // Performs handshake and returns typed READY data when available.
+    let ready = client.connect_with_ready()?;
+
+    match ready.and_then(|r| r.user) {
+        Some(user) => {
+            if let Some(username) = user.username {
+                println!("[Discord] Authenticated as {username}");
+            }
+            if let Some(id) = user.id {
+                println!("[Discord] User ID: {id}");
+            }
+        }
+        None => {
+            eprintln!("READY event payload did not include user info");
+        }
+    }
+
+    client.close();
+    Ok(())
+}

--- a/migrations/v0.2.0-migration-guide.md
+++ b/migrations/v0.2.0-migration-guide.md
@@ -1,0 +1,136 @@
+# PresenceForge v0.2.0 Migration Guide
+
+This guide describes how to migrate your code from PresenceForge v0.1.0 to v0.2.0.
+
+## 1. Version Bump
+
+Update your `Cargo.toml`:
+
+```toml
+[dependencies]
+# Old
+# presenceforge = "0.1.0"
+
+# New
+presenceforge = "0.2.0"
+```
+
+---
+
+## 2. Refactored Error Handling
+
+In v0.1.0, errors were largely string-based or used simple variants. In v0.2.0, `DiscordIpcError` is now a fully-typed enum with specialized variants for different categories.
+
+### Old Code (v0.1.0):
+```rust
+match client.set_activity(&activity) {
+    Err(DiscordIpcError::ConnectionFailed(msg)) => eprintln!("Failed: {}", msg),
+    _ => {}
+}
+```
+
+### New Code (v0.2.0):
+```rust
+match client.set_activity(&activity) {
+    Err(DiscordIpcError::ConnectionFailed(io_error)) => {
+        eprintln!("Socket error: {}", io_error);
+    }
+    Err(DiscordIpcError::DiscordError { code, message }) => {
+        eprintln!("Discord API error {}: {}", code, message);
+    }
+    Err(e) if e.is_connection_error() => {
+        client.reconnect()?;
+    }
+    _ => {}
+}
+```
+
+**Key Changes:**
+- `ConnectionFailed` now wraps `std::io::Error`.
+- Added `DiscordError` for errors returned directly by the Discord IPC.
+- Added `is_connection_error()` and `is_recoverable()` helper methods.
+
+---
+
+## 3. Native Reconnection
+
+You no longer need to manually recreate the `DiscordIpcClient` if the connection is lost.
+
+### Old Code (v0.1.0):
+```rust
+if connection_lost {
+    client = DiscordIpcClient::new(client_id)?;
+    client.connect()?;
+}
+```
+
+### New Code (v0.2.0):
+```rust
+if connection_lost {
+    client.reconnect()?; // Closes old connection and handshakes automatically
+}
+```
+
+---
+
+## 4. Event System Integration
+
+v0.2.0 introduces a full IPC event system. If you were manually parsing payloads to find events, you can now use the built-in methods.
+
+### New Features:
+- `client.subscribe(event_name, args)`
+- `client.unsubscribe(event_name, args)`
+- `client.next_event()` (blocking)
+- `client.poll_event()` (non-blocking)
+
+Example:
+```rust
+client.subscribe("ACTIVITY_JOIN", json!({}))?;
+loop {
+    if let Ok(EventData::ActivityJoin(join)) = client.next_event() {
+        println!("User joined with secret: {}", join.secret);
+    }
+}
+```
+
+---
+
+## 5. ActivityBuilder Helpers
+
+Several convenience methods have been added to the builder.
+
+### End Timestamps:
+```rust
+// Old: Manual math
+let end = now + 600;
+builder.end_timestamp(end);
+
+// New: Duration-based
+builder.end_timestamp_from_now(Duration::from_secs(600))?;
+```
+
+### Simple Parties:
+```rust
+// Old: Manual UUID generation
+builder.party("unique-id-123", 1, 4);
+
+// New: Auto-generated UUID
+builder.party_simple(1, 4);
+```
+
+---
+
+## 6. Internal Debugging
+
+To see internal handshake and payload logs, you now need to set an environment variable:
+
+```bash
+# Enable library debug emission
+PRESENCEFORGE_DEBUG=1 RUST_LOG=debug cargo run
+```
+
+---
+
+## Still Having Trouble?
+
+If you encounter issues during migration, please check the [API Reference](../docs/API_REFERENCE.md) or open an issue on GitHub.

--- a/scripts/spdx.py
+++ b/scripts/spdx.py
@@ -16,12 +16,10 @@ def stamp_files(root_dir):
                 with open(file_path, 'r', encoding='utf-8') as f:
                     content = f.readlines()
 
-                # Check if already stamped so we don't look like an amateur
                 if content and "SPDX-License-Identifier" in content[0]:
                     print(f"[-] Skipping: {file} (Already protected)")
                     continue
 
-                # Inject the legal virus at the top
                 print(f"[+] Stamping: {file}")
                 with open(file_path, 'w', encoding='utf-8') as f:
                     f.write(SPDX_TAG)

--- a/src/activity/builder.rs
+++ b/src/activity/builder.rs
@@ -37,9 +37,9 @@ impl ActivityBuilder {
     /// Returns an error if the system time is before the UNIX epoch (Jan 1, 1970).
     /// This should never happen on properly configured systems.
     pub fn start_timestamp_now(mut self) -> Result<Self> {
-        let now = SystemTime::now().duration_since(UNIX_EPOCH).map_err(|e| {
-            DiscordIpcError::SystemTimeError(format!("System time is before UNIX epoch: {}", e))
-        })?;
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(DiscordIpcError::SystemTimeError)?;
 
         self.get_timestamps().start = Some(now.as_secs());
         Ok(self)

--- a/src/activity/builder.rs
+++ b/src/activity/builder.rs
@@ -57,6 +57,21 @@ impl ActivityBuilder {
         self
     }
 
+    /// Set the end timestamp relative to current time
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the system time is before the UNIX epoch.
+    pub fn end_timestamp_from_now(mut self, duration: std::time::Duration) -> Result<Self> {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(DiscordIpcError::SystemTimeError)?;
+
+        let end = now + duration;
+        self.get_timestamps().end = Some(end.as_secs() as i64);
+        Ok(self)
+    }
+
     /// Set the large image asset
     pub fn large_image<S: Into<String>>(mut self, key: S) -> Self {
         self.get_assets().large_image = Some(key.into());
@@ -85,6 +100,15 @@ impl ActivityBuilder {
     pub fn party<S: Into<String>>(mut self, id: S, current_size: u32, max_size: u32) -> Self {
         self.activity.party = Some(ActivityParty {
             id: Some(id.into()),
+            size: Some([current_size, max_size]),
+        });
+        self
+    }
+
+    /// Set party information with an automatically generated ID
+    pub fn party_simple(mut self, current_size: u32, max_size: u32) -> Self {
+        self.activity.party = Some(ActivityParty {
+            id: Some(uuid::Uuid::new_v4().to_string()),
             size: Some([current_size, max_size]),
         });
         self
@@ -188,6 +212,14 @@ mod tests {
     }
 
     #[test]
+    fn builder_sets_party_simple() {
+        let activity = ActivityBuilder::new().party_simple(3, 10).build();
+        let party = activity.party.unwrap();
+        assert!(party.id.is_some());
+        assert_eq!(party.size, Some([3, 10]));
+    }
+
+    #[test]
     fn start_timestamp_now_sets_current_time() {
         let before = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -217,6 +249,23 @@ mod tests {
         let timestamps = activity.timestamps.unwrap();
         assert_eq!(timestamps.start, Some(100));
         assert_eq!(timestamps.end, Some(200));
+    }
+
+    #[test]
+    fn end_timestamp_from_now_works() {
+        let activity = ActivityBuilder::new()
+            .end_timestamp_from_now(std::time::Duration::from_secs(60))
+            .unwrap()
+            .build();
+
+        let end = activity.timestamps.unwrap().end.unwrap();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+
+        assert!(end >= now + 58);
+        assert!(end <= now + 62);
     }
 
     #[cfg(feature = "secrets")]

--- a/src/activity/types.rs
+++ b/src/activity/types.rs
@@ -7,19 +7,49 @@ use std::fmt;
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ActivityValidationError {
-    StateTooLong { max: usize, actual: usize },
-    DetailsTooLong { max: usize, actual: usize },
-    TooManyButtons { max: usize, actual: usize },
-    ButtonLabelTooLong { max: usize, actual: usize },
-    ButtonUrlTooLong { max: usize, actual: usize },
+    StateTooLong {
+        max: usize,
+        actual: usize,
+    },
+    DetailsTooLong {
+        max: usize,
+        actual: usize,
+    },
+    TooManyButtons {
+        max: usize,
+        actual: usize,
+    },
+    ButtonLabelTooLong {
+        max: usize,
+        actual: usize,
+    },
+    ButtonUrlTooLong {
+        max: usize,
+        actual: usize,
+    },
     ButtonUrlMissingScheme,
     #[cfg(feature = "secrets")]
     ButtonsAndSecretsConflict,
-    LargeImageKeyTooLong { max: usize, actual: usize },
-    SmallImageKeyTooLong { max: usize, actual: usize },
-    LargeTextTooLong { max: usize, actual: usize },
-    SmallTextTooLong { max: usize, actual: usize },
-    PartySizeExceedsMax { current: u32, max: u32 },
+    LargeImageKeyTooLong {
+        max: usize,
+        actual: usize,
+    },
+    SmallImageKeyTooLong {
+        max: usize,
+        actual: usize,
+    },
+    LargeTextTooLong {
+        max: usize,
+        actual: usize,
+    },
+    SmallTextTooLong {
+        max: usize,
+        actual: usize,
+    },
+    PartySizeExceedsMax {
+        current: u32,
+        max: u32,
+    },
 }
 
 impl fmt::Display for ActivityValidationError {
@@ -32,13 +62,22 @@ impl fmt::Display for ActivityValidationError {
                 write!(f, "Details must be {max} characters or less (got {actual})")
             }
             Self::TooManyButtons { max, actual } => {
-                write!(f, "Discord allows a maximum of {max} buttons (got {actual})")
+                write!(
+                    f,
+                    "Discord allows a maximum of {max} buttons (got {actual})"
+                )
             }
             Self::ButtonLabelTooLong { max, actual } => {
-                write!(f, "Button label must be {max} characters or less (got {actual})")
+                write!(
+                    f,
+                    "Button label must be {max} characters or less (got {actual})"
+                )
             }
             Self::ButtonUrlTooLong { max, actual } => {
-                write!(f, "Button URL must be {max} characters or less (got {actual})")
+                write!(
+                    f,
+                    "Button URL must be {max} characters or less (got {actual})"
+                )
             }
             Self::ButtonUrlMissingScheme => {
                 write!(f, "Button URL must start with http:// or https://")
@@ -48,16 +87,28 @@ impl fmt::Display for ActivityValidationError {
                 write!(f, "Buttons and secrets cannot coexist in the same Activity")
             }
             Self::LargeImageKeyTooLong { max, actual } => {
-                write!(f, "Large image key must be {max} characters or less (got {actual})")
+                write!(
+                    f,
+                    "Large image key must be {max} characters or less (got {actual})"
+                )
             }
             Self::SmallImageKeyTooLong { max, actual } => {
-                write!(f, "Small image key must be {max} characters or less (got {actual})")
+                write!(
+                    f,
+                    "Small image key must be {max} characters or less (got {actual})"
+                )
             }
             Self::LargeTextTooLong { max, actual } => {
-                write!(f, "Large text must be {max} characters or less (got {actual})")
+                write!(
+                    f,
+                    "Large text must be {max} characters or less (got {actual})"
+                )
             }
             Self::SmallTextTooLong { max, actual } => {
-                write!(f, "Small text must be {max} characters or less (got {actual})")
+                write!(
+                    f,
+                    "Small text must be {max} characters or less (got {actual})"
+                )
             }
             Self::PartySizeExceedsMax { current, max } => write!(
                 f,

--- a/src/activity/types.rs
+++ b/src/activity/types.rs
@@ -118,6 +118,8 @@ impl fmt::Display for ActivityValidationError {
     }
 }
 
+impl std::error::Error for ActivityValidationError {}
+
 /// Rich Presence Activity
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Activity {

--- a/src/activity/types.rs
+++ b/src/activity/types.rs
@@ -1,6 +1,71 @@
 #![allow(clippy::collapsible_if)]
 
 use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Typed validation failures for `Activity`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ActivityValidationError {
+    StateTooLong { max: usize, actual: usize },
+    DetailsTooLong { max: usize, actual: usize },
+    TooManyButtons { max: usize, actual: usize },
+    ButtonLabelTooLong { max: usize, actual: usize },
+    ButtonUrlTooLong { max: usize, actual: usize },
+    ButtonUrlMissingScheme,
+    #[cfg(feature = "secrets")]
+    ButtonsAndSecretsConflict,
+    LargeImageKeyTooLong { max: usize, actual: usize },
+    SmallImageKeyTooLong { max: usize, actual: usize },
+    LargeTextTooLong { max: usize, actual: usize },
+    SmallTextTooLong { max: usize, actual: usize },
+    PartySizeExceedsMax { current: u32, max: u32 },
+}
+
+impl fmt::Display for ActivityValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::StateTooLong { max, actual } => {
+                write!(f, "State must be {max} characters or less (got {actual})")
+            }
+            Self::DetailsTooLong { max, actual } => {
+                write!(f, "Details must be {max} characters or less (got {actual})")
+            }
+            Self::TooManyButtons { max, actual } => {
+                write!(f, "Discord allows a maximum of {max} buttons (got {actual})")
+            }
+            Self::ButtonLabelTooLong { max, actual } => {
+                write!(f, "Button label must be {max} characters or less (got {actual})")
+            }
+            Self::ButtonUrlTooLong { max, actual } => {
+                write!(f, "Button URL must be {max} characters or less (got {actual})")
+            }
+            Self::ButtonUrlMissingScheme => {
+                write!(f, "Button URL must start with http:// or https://")
+            }
+            #[cfg(feature = "secrets")]
+            Self::ButtonsAndSecretsConflict => {
+                write!(f, "Buttons and secrets cannot coexist in the same Activity")
+            }
+            Self::LargeImageKeyTooLong { max, actual } => {
+                write!(f, "Large image key must be {max} characters or less (got {actual})")
+            }
+            Self::SmallImageKeyTooLong { max, actual } => {
+                write!(f, "Small image key must be {max} characters or less (got {actual})")
+            }
+            Self::LargeTextTooLong { max, actual } => {
+                write!(f, "Large text must be {max} characters or less (got {actual})")
+            }
+            Self::SmallTextTooLong { max, actual } => {
+                write!(f, "Small text must be {max} characters or less (got {actual})")
+            }
+            Self::PartySizeExceedsMax { current, max } => write!(
+                f,
+                "Current party size cannot be greater than max party size ({current}/{max})"
+            ),
+        }
+    }
+}
 
 /// Rich Presence Activity
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -36,18 +101,24 @@ impl Activity {
     ///
     /// # Returns
     ///
-    /// Ok(()) if valid, or Err(String) with the reason if invalid
-    pub fn validate(&self) -> Result<(), String> {
+    /// Ok(()) if valid, or Err(ActivityValidationError) with the reason if invalid
+    pub fn validate(&self) -> Result<(), ActivityValidationError> {
         // Check text field lengths
         if let Some(state) = &self.state {
             if state.len() > 128 {
-                return Err("State must be 128 characters or less".to_string());
+                return Err(ActivityValidationError::StateTooLong {
+                    max: 128,
+                    actual: state.len(),
+                });
             }
         }
 
         if let Some(details) = &self.details {
             if details.len() > 128 {
-                return Err("Details must be 128 characters or less".to_string());
+                return Err(ActivityValidationError::DetailsTooLong {
+                    max: 128,
+                    actual: details.len(),
+                });
             }
         }
 
@@ -55,21 +126,30 @@ impl Activity {
         if let Some(buttons) = &self.buttons {
             // Discord allows a maximum of 2 buttons
             if buttons.len() > 2 {
-                return Err("Discord allows a maximum of 2 buttons".to_string());
+                return Err(ActivityValidationError::TooManyButtons {
+                    max: 2,
+                    actual: buttons.len(),
+                });
             }
 
             for button in buttons {
                 if button.label.len() > 32 {
-                    return Err("Button label must be 32 characters or less".to_string());
+                    return Err(ActivityValidationError::ButtonLabelTooLong {
+                        max: 32,
+                        actual: button.label.len(),
+                    });
                 }
 
                 if button.url.len() > 512 {
-                    return Err("Button URL must be 512 characters or less".to_string());
+                    return Err(ActivityValidationError::ButtonUrlTooLong {
+                        max: 512,
+                        actual: button.url.len(),
+                    });
                 }
 
                 // Validate URL format (simple check)
                 if !button.url.starts_with("http://") && !button.url.starts_with("https://") {
-                    return Err("Button URL must start with http:// or https://".to_string());
+                    return Err(ActivityValidationError::ButtonUrlMissingScheme);
                 }
             }
         }
@@ -88,7 +168,7 @@ impl Activity {
                     .map(|s| s.join.is_some() || s.spectate.is_some() || s.match_secret.is_some())
                     .unwrap_or(false)
             {
-                return Err("Buttons and secrets cannot coexist in the same Activity".to_string());
+                return Err(ActivityValidationError::ButtonsAndSecretsConflict);
             }
         }
 
@@ -96,25 +176,37 @@ impl Activity {
         if let Some(assets) = &self.assets {
             if let Some(large_image) = &assets.large_image {
                 if large_image.len() > 256 {
-                    return Err("Large image key must be 256 characters or less".to_string());
+                    return Err(ActivityValidationError::LargeImageKeyTooLong {
+                        max: 256,
+                        actual: large_image.len(),
+                    });
                 }
             }
 
             if let Some(small_image) = &assets.small_image {
                 if small_image.len() > 256 {
-                    return Err("Small image key must be 256 characters or less".to_string());
+                    return Err(ActivityValidationError::SmallImageKeyTooLong {
+                        max: 256,
+                        actual: small_image.len(),
+                    });
                 }
             }
 
             if let Some(large_text) = &assets.large_text {
                 if large_text.len() > 128 {
-                    return Err("Large text must be 128 characters or less".to_string());
+                    return Err(ActivityValidationError::LargeTextTooLong {
+                        max: 128,
+                        actual: large_text.len(),
+                    });
                 }
             }
 
             if let Some(small_text) = &assets.small_text {
                 if small_text.len() > 128 {
-                    return Err("Small text must be 128 characters or less".to_string());
+                    return Err(ActivityValidationError::SmallTextTooLong {
+                        max: 128,
+                        actual: small_text.len(),
+                    });
                 }
             }
         }
@@ -122,7 +214,10 @@ impl Activity {
         // Validate party size
         if let Some(size) = self.party.as_ref().and_then(|n| n.size) {
             if size[0] > size[1] {
-                return Err("Current party size cannot be greater than max party size".to_string());
+                return Err(ActivityValidationError::PartySizeExceedsMax {
+                    current: size[0],
+                    max: size[1],
+                });
             }
         }
 
@@ -238,22 +333,28 @@ mod tests {
             state: Some("a".repeat(129)),
             ..Default::default()
         };
-        let error = activity.validate().unwrap_err();
-        assert!(error.contains("128"));
+        assert!(matches!(
+            activity.validate().unwrap_err(),
+            ActivityValidationError::StateTooLong { .. }
+        ));
     }
 
     #[test]
     fn button_label_too_long_fails() {
         let activity = activity_with_button(&"x".repeat(33), "https://example.com");
-        let error = activity.validate().unwrap_err();
-        assert!(error.contains("Button label"));
+        assert!(matches!(
+            activity.validate().unwrap_err(),
+            ActivityValidationError::ButtonLabelTooLong { .. }
+        ));
     }
 
     #[test]
     fn button_url_without_scheme_fails() {
         let activity = activity_with_button("Join", "example.com");
-        let error = activity.validate().unwrap_err();
-        assert!(error.contains("http://"));
+        assert!(matches!(
+            activity.validate().unwrap_err(),
+            ActivityValidationError::ButtonUrlMissingScheme
+        ));
     }
 
     #[test]
@@ -266,8 +367,10 @@ mod tests {
             ..Default::default()
         };
 
-        let error = activity.validate().unwrap_err();
-        assert!(error.contains("Large image key"));
+        assert!(matches!(
+            activity.validate().unwrap_err(),
+            ActivityValidationError::LargeImageKeyTooLong { .. }
+        ));
     }
 
     #[test]
@@ -280,8 +383,10 @@ mod tests {
             ..Default::default()
         };
 
-        let error = activity.validate().unwrap_err();
-        assert!(error.contains("Current party size"));
+        assert!(matches!(
+            activity.validate().unwrap_err(),
+            ActivityValidationError::PartySizeExceedsMax { .. }
+        ));
     }
 
     #[test]
@@ -301,7 +406,9 @@ mod tests {
             ..Default::default()
         };
 
-        let err = activity.validate().unwrap_err();
-        assert!(err.contains("Buttons and secrets cannot coexist"));
+        assert!(matches!(
+            activity.validate().unwrap_err(),
+            ActivityValidationError::ButtonsAndSecretsConflict
+        ));
     }
 }

--- a/src/async_io/async_std/mod.rs
+++ b/src/async_io/async_std/mod.rs
@@ -400,9 +400,7 @@ pub mod client {
         }
 
         /// Parse a raw IPC payload into a READY event if this payload is a READY dispatch.
-        pub fn ready_event_from_payload(
-            payload: &Value,
-        ) -> Result<Option<crate::ipc::ReadyEvent>> {
+        pub fn ready_event_from_payload(payload: &Value) -> Result<Option<crate::ipc::ReadyEvent>> {
             AsyncDiscordIpcClient::<AsyncStdConnection>::ready_event_from_payload(payload)
         }
 

--- a/src/async_io/async_std/mod.rs
+++ b/src/async_io/async_std/mod.rs
@@ -394,6 +394,11 @@ pub mod client {
             self.inner.connect().await
         }
 
+        /// Returns `true` once a handshake has been successfully completed.
+        pub fn is_connected(&self) -> bool {
+            self.inner.is_connected()
+        }
+
         /// Sets Discord Rich Presence activity
         pub async fn set_activity(&mut self, activity: &crate::activity::Activity) -> Result<()> {
             self.inner.set_activity(activity).await

--- a/src/async_io/async_std/mod.rs
+++ b/src/async_io/async_std/mod.rs
@@ -348,11 +348,7 @@ pub mod client {
         }
 
         /// Unsubscribe from a Discord IPC event.
-        pub async fn unsubscribe<S: Into<String>>(
-            &mut self,
-            event: S,
-            args: Value,
-        ) -> Result<()> {
+        pub async fn unsubscribe<S: Into<String>>(&mut self, event: S, args: Value) -> Result<()> {
             self.inner.unsubscribe(event, args).await
         }
 

--- a/src/async_io/async_std/mod.rs
+++ b/src/async_io/async_std/mod.rs
@@ -394,6 +394,18 @@ pub mod client {
             self.inner.connect().await
         }
 
+        /// Perform handshake and return the typed READY payload when available.
+        pub async fn connect_with_ready(&mut self) -> Result<Option<crate::ipc::ReadyEvent>> {
+            self.inner.connect_with_ready().await
+        }
+
+        /// Parse a raw IPC payload into a READY event if this payload is a READY dispatch.
+        pub fn ready_event_from_payload(
+            payload: &Value,
+        ) -> Result<Option<crate::ipc::ReadyEvent>> {
+            AsyncDiscordIpcClient::<AsyncStdConnection>::ready_event_from_payload(payload)
+        }
+
         /// Returns `true` once a handshake has been successfully completed.
         pub fn is_connected(&self) -> bool {
             self.inner.is_connected()

--- a/src/async_io/async_std/mod.rs
+++ b/src/async_io/async_std/mod.rs
@@ -12,11 +12,7 @@ use async_std::io::WriteExt as _;
 use async_std::os::unix::net::UnixStream;
 
 #[cfg(windows)]
-use std::fs::File;
-#[cfg(windows)]
-use std::io::{Read, Write};
-#[cfg(windows)]
-use std::sync::{Arc, Mutex};
+use async_std::fs::File;
 
 use crate::async_io::traits::{AsyncRead, AsyncWrite};
 use crate::debug_println;
@@ -29,7 +25,7 @@ pub(crate) enum AsyncStdConnection {
     Unix(UnixStream),
 
     #[cfg(windows)]
-    Windows(Arc<Mutex<File>>),
+    Windows(File),
 }
 
 impl AsyncStdConnection {
@@ -94,44 +90,16 @@ impl AsyncStdConnection {
     #[cfg(unix)]
     /// Connect to Discord IPC socket using auto-discovery
     async fn connect_unix_auto() -> Result<Self> {
-        // Try environment variables in order of preference
-        let env_keys = ["XDG_RUNTIME_DIR", "TMPDIR", "TMP", "TEMP"];
-        let mut directories = Vec::new();
-
-        for env_key in &env_keys {
-            if let Ok(dir) = std::env::var(env_key) {
-                directories.push(dir.clone());
-
-                // Also check Flatpak Discord path if XDG_RUNTIME_DIR is set
-                if env_key == &"XDG_RUNTIME_DIR" {
-                    directories.push(format!("{}/app/com.discordapp.Discord", dir));
-                }
-            }
-        }
-
-        // Fallback to /run/user/{uid} if no env vars found
-        if directories.is_empty() {
-            let uid = unsafe { libc::getuid() };
-            directories.push(format!("/run/user/{}", uid));
-            // Also try Flatpak path as fallback
-            directories.push(format!("/run/user/{}/app/com.discordapp.Discord", uid));
-        }
-
-        // Try each directory with each socket number
         let mut last_error = None;
 
-        for dir in &directories {
-            for i in 0..constants::MAX_IPC_SOCKETS {
-                let socket_path = format!("{}/{}{}", dir, constants::IPC_SOCKET_PREFIX, i);
-
-                match UnixStream::connect(&socket_path).await {
-                    Ok(stream) => {
-                        return Ok(Self::Unix(stream));
-                    }
-                    Err(err) => {
-                        last_error = Some(err);
-                        continue;
-                    }
+        for socket_path in crate::ipc::discovery::get_socket_paths() {
+            match UnixStream::connect(&socket_path).await {
+                Ok(stream) => {
+                    return Ok(Self::Unix(stream));
+                }
+                Err(err) => {
+                    last_error = Some(err);
+                    continue;
                 }
             }
         }
@@ -162,14 +130,18 @@ impl AsyncStdConnection {
                 use std::os::windows::fs::OpenOptionsExt;
                 const FILE_FLAG_OVERLAPPED: u32 = 0x40000000;
 
-                let file = OpenOptions::new()
-                    .read(true)
-                    .write(true)
-                    .custom_flags(FILE_FLAG_OVERLAPPED)
-                    .open(path)
-                    .map_err(DiscordIpcError::ConnectionFailed)?;
+                let path_clone = path.clone();
+                let file = blocking::unblock(move || {
+                    OpenOptions::new()
+                        .read(true)
+                        .write(true)
+                        .custom_flags(FILE_FLAG_OVERLAPPED)
+                        .open(&path_clone)
+                })
+                .await
+                .map_err(DiscordIpcError::ConnectionFailed)?;
 
-                Ok(Self::Windows(Arc::new(Mutex::new(file))))
+                Ok(Self::Windows(File::from(file)))
             }
         }
     }
@@ -183,9 +155,7 @@ impl AsyncStdConnection {
 
         let mut last_error = None;
 
-        for i in 0..constants::MAX_IPC_SOCKETS {
-            let pipe_path = format!(r"\\.\pipe\discord-ipc-{}", i);
-
+        for pipe_path in crate::ipc::discovery::get_pipe_paths() {
             debug_println!("Attempting to connect to Windows named pipe: {}", pipe_path);
 
             // Clone pipe_path for the closure
@@ -194,7 +164,6 @@ impl AsyncStdConnection {
             // Open the named pipe with overlapped I/O support
             // We use blocking operations wrapped in async context via the blocking crate
             // this can cause a perfomance loss but there was no other way i could think of
-            // Todo : write a better solution for the below code
 
             let result = blocking::unblock(move || {
                 OpenOptions::new()
@@ -208,7 +177,7 @@ impl AsyncStdConnection {
             match result {
                 Ok(file) => {
                     debug_println!("Successfully opened named pipe: {}", pipe_path);
-                    return Ok(Self::Windows(Arc::new(Mutex::new(file))));
+                    return Ok(Self::Windows(File::from(file)));
                 }
                 Err(err) => {
                     debug_println!("Failed to connect to named pipe {}: {}", pipe_path, err);
@@ -243,37 +212,15 @@ impl AsyncRead for AsyncStdConnection {
         Box::pin(async move {
             match self {
                 #[cfg(unix)]
-                Self::Unix(stream) => stream.read(buf).await,
+                Self::Unix(stream) => {
+                    use async_std::io::ReadExt;
+                    stream.read(buf).await
+                }
 
                 #[cfg(windows)]
                 Self::Windows(pipe) => {
-                    // Clone the Arc to pass into the blocking task
-                    let pipe_clone = Arc::clone(pipe);
-                    let buf_len = buf.len();
-
-                    // Use blocking crate to handle synchronous I/O in async context
-                    let result = blocking::unblock(move || {
-                        let mut local_buf = vec![0u8; buf_len];
-                        let mut file = match pipe_clone.lock().map_err(|e| {
-                            io::Error::new(io::ErrorKind::Other, format!("Mutex poisoned: {}", e))
-                        }) {
-                            Ok(f) => f,
-                            Err(e) => return Err(e),
-                        };
-                        match file.read(&mut local_buf) {
-                            Ok(n) => Ok((n, local_buf)),
-                            Err(e) => Err(e),
-                        }
-                    })
-                    .await;
-
-                    match result {
-                        Ok((n, data)) => {
-                            buf[..n].copy_from_slice(&data[..n]);
-                            Ok(n)
-                        }
-                        Err(e) => Err(e),
-                    }
+                    use async_std::io::ReadExt;
+                    pipe.read(buf).await
                 }
             }
         })
@@ -288,28 +235,15 @@ impl AsyncWrite for AsyncStdConnection {
         Box::pin(async move {
             match self {
                 #[cfg(unix)]
-                Self::Unix(stream) => stream.write(buf).await,
+                Self::Unix(stream) => {
+                    use async_std::io::WriteExt;
+                    stream.write(buf).await
+                }
 
                 #[cfg(windows)]
                 Self::Windows(pipe) => {
-                    // Clone the Arc to pass into the blocking task
-                    let pipe_clone = Arc::clone(pipe);
-                    let data = buf.to_vec();
-
-                    // Use blocking crate to handle synchronous I/O in async context
-                    blocking::unblock(move || {
-                        let mut file = match pipe_clone.lock() {
-                            Ok(f) => f,
-                            Err(e) => {
-                                return Err(io::Error::new(
-                                    io::ErrorKind::Other,
-                                    format!("Mutex poisoned: {}", e),
-                                ));
-                            }
-                        };
-                        file.write(&data)
-                    })
-                    .await
+                    use async_std::io::WriteExt;
+                    pipe.write(buf).await
                 }
             }
         })
@@ -319,26 +253,15 @@ impl AsyncWrite for AsyncStdConnection {
         Box::pin(async move {
             match self {
                 #[cfg(unix)]
-                Self::Unix(stream) => stream.flush().await,
+                Self::Unix(stream) => {
+                    use async_std::io::WriteExt;
+                    stream.flush().await
+                }
 
                 #[cfg(windows)]
                 Self::Windows(pipe) => {
-                    // Clone the Arc to pass into the blocking task
-                    let pipe_clone = Arc::clone(pipe);
-
-                    blocking::unblock(move || {
-                        let mut file = match pipe_clone.lock() {
-                            Ok(f) => f,
-                            Err(e) => {
-                                return Err(io::Error::new(
-                                    io::ErrorKind::Other,
-                                    format!("Mutex poisoned: {}", e),
-                                ));
-                            }
-                        };
-                        file.flush()
-                    })
-                    .await
+                    use async_std::io::WriteExt;
+                    pipe.flush().await
                 }
             }
         })
@@ -417,6 +340,25 @@ pub mod client {
         /// Clears Discord Rich Presence activity
         pub async fn clear_activity(&mut self) -> Result<Value> {
             self.inner.clear_activity().await
+        }
+
+        /// Subscribe to a Discord IPC event.
+        pub async fn subscribe<S: Into<String>>(&mut self, event: S, args: Value) -> Result<()> {
+            self.inner.subscribe(event, args).await
+        }
+
+        /// Unsubscribe from a Discord IPC event.
+        pub async fn unsubscribe<S: Into<String>>(
+            &mut self,
+            event: S,
+            args: Value,
+        ) -> Result<()> {
+            self.inner.unsubscribe(event, args).await
+        }
+
+        /// Wait for the next IPC event.
+        pub async fn next_event(&mut self) -> Result<crate::ipc::EventData> {
+            self.inner.next_event().await
         }
 
         /// Reconnect to Discord IPC

--- a/src/async_io/client.rs
+++ b/src/async_io/client.rs
@@ -13,7 +13,9 @@ use super::traits::{read_exact, write_all, AsyncRead, AsyncWrite};
 use crate::activity::Activity;
 use crate::debug_println;
 use crate::error::{DiscordIpcError, Result};
-use crate::ipc::{constants, Command, HandshakePayload, IpcMessage, Opcode};
+use crate::ipc::{
+    constants, Command, EventData, HandshakePayload, IpcMessage, IpcResponse, Opcode, ReadyEvent,
+};
 use crate::nonce::generate_nonce;
 
 /// Async implementation of Discord IPC client
@@ -102,6 +104,23 @@ where
 
         self.connected = true;
         Ok(response)
+    }
+
+    /// Perform handshake and return the typed READY payload when available.
+    pub async fn connect_with_ready(&mut self) -> Result<Option<ReadyEvent>> {
+        let response = self.connect().await?;
+        Self::ready_event_from_payload(&response)
+    }
+
+    /// Parse a raw IPC payload into a READY event if this payload is a READY dispatch.
+    pub fn ready_event_from_payload(payload: &Value) -> Result<Option<ReadyEvent>> {
+        let response: IpcResponse = serde_json::from_value(payload.clone())
+            .map_err(DiscordIpcError::DeserializationFailed)?;
+
+        match response.parse_event()? {
+            Some(EventData::Ready(ready)) => Ok(Some(ready)),
+            Some(EventData::Unknown { .. }) | None => Ok(None),
+        }
     }
 
     /// Sets Discord Rich Presence activity

--- a/src/async_io/client.rs
+++ b/src/async_io/client.rs
@@ -12,7 +12,9 @@ use super::traits::ipc_utils::read_u32_le;
 use super::traits::{read_exact, write_all, AsyncRead, AsyncWrite};
 use crate::activity::Activity;
 use crate::debug_println;
-use crate::error::{DiscordIpcError, Result};
+use crate::error::{
+    DiscordIpcError, HandshakeFailureKind, InvalidActivityKind, InvalidResponseKind, Result,
+};
 use crate::ipc::{
     constants, Command, EventData, HandshakePayload, IpcMessage, IpcResponse, Opcode, ReadyEvent,
 };
@@ -87,19 +89,19 @@ where
             ) {
                 return Err(DiscordIpcError::discord_error(code as i32, message));
             } else {
-                return Err(DiscordIpcError::HandshakeFailed(format!(
-                    "Invalid error format: {}",
-                    err
-                )));
+                return Err(DiscordIpcError::handshake_failed(
+                    HandshakeFailureKind::InvalidErrorPayload,
+                    format!("Invalid error format: {}", err),
+                ));
             }
         }
 
         // Verify opcode is correct for handshake response
         if !opcode.is_handshake_response() {
-            return Err(DiscordIpcError::HandshakeFailed(format!(
-                "Expected handshake response opcode, got {:?}",
-                opcode
-            )));
+            return Err(DiscordIpcError::handshake_failed(
+                HandshakeFailureKind::UnexpectedOpcode,
+                format!("Expected handshake response opcode, got {:?}", opcode),
+            ));
         }
 
         self.connected = true;
@@ -135,7 +137,10 @@ where
     pub async fn set_activity(&mut self, activity: &Activity) -> Result<()> {
         // Validate the activity first
         if let Err(reason) = activity.validate() {
-            return Err(DiscordIpcError::InvalidActivity(reason));
+            return Err(DiscordIpcError::invalid_activity(
+                InvalidActivityKind::ValidationFailed,
+                reason,
+            ));
         }
 
         // Generate a cryptographically secure unique nonce for this request
@@ -158,10 +163,10 @@ where
 
         // Check if we got the correct response type
         if !opcode.is_frame_response() {
-            return Err(DiscordIpcError::InvalidResponse(format!(
-                "Expected frame response, got {:?}",
-                opcode
-            )));
+            return Err(DiscordIpcError::invalid_response(
+                InvalidResponseKind::UnexpectedOpcode,
+                format!("Expected frame response, got {:?}", opcode),
+            ));
         }
 
         // Check for error in the response
@@ -172,20 +177,20 @@ where
             ) {
                 return Err(DiscordIpcError::discord_error(code as i32, message));
             } else {
-                return Err(DiscordIpcError::InvalidResponse(format!(
-                    "Invalid error format in response: {}",
-                    err
-                )));
+                return Err(DiscordIpcError::invalid_response(
+                    InvalidResponseKind::InvalidErrorPayload,
+                    format!("Invalid error format in response: {}", err),
+                ));
             }
         }
 
         // Verify nonce matches to ensure we got the right response
         if let Some(resp_nonce) = response.get("nonce").and_then(|n| n.as_str()) {
             if resp_nonce != nonce {
-                return Err(DiscordIpcError::InvalidResponse(format!(
-                    "Nonce mismatch: expected {}, got {}",
-                    nonce, resp_nonce
-                )));
+                return Err(DiscordIpcError::invalid_response(
+                    InvalidResponseKind::NonceMismatch,
+                    format!("Nonce mismatch: expected {}, got {}", nonce, resp_nonce),
+                ));
             }
         }
 
@@ -222,10 +227,10 @@ where
 
         // Check if we got the correct response type
         if !opcode.is_frame_response() {
-            return Err(DiscordIpcError::InvalidResponse(format!(
-                "Expected frame response, got {:?}",
-                opcode
-            )));
+            return Err(DiscordIpcError::invalid_response(
+                InvalidResponseKind::UnexpectedOpcode,
+                format!("Expected frame response, got {:?}", opcode),
+            ));
         }
 
         // Check for error in the response
@@ -236,20 +241,20 @@ where
             ) {
                 return Err(DiscordIpcError::discord_error(code as i32, message));
             } else {
-                return Err(DiscordIpcError::InvalidResponse(format!(
-                    "Invalid error format in response: {}",
-                    err
-                )));
+                return Err(DiscordIpcError::invalid_response(
+                    InvalidResponseKind::InvalidErrorPayload,
+                    format!("Invalid error format in response: {}", err),
+                ));
             }
         }
 
         // Verify nonce matches to ensure we got the right response
         if let Some(resp_nonce) = response.get("nonce").and_then(|n| n.as_str()) {
             if resp_nonce != nonce {
-                return Err(DiscordIpcError::InvalidResponse(format!(
-                    "Nonce mismatch: expected {}, got {}",
-                    nonce, resp_nonce
-                )));
+                return Err(DiscordIpcError::invalid_response(
+                    InvalidResponseKind::NonceMismatch,
+                    format!("Nonce mismatch: expected {}, got {}", nonce, resp_nonce),
+                ));
             }
         }
 
@@ -351,11 +356,14 @@ where
 
         // Validate payload size to prevent excessive memory allocation
         if length > crate::ipc::protocol::constants::MAX_PAYLOAD_SIZE {
-            return Err(DiscordIpcError::InvalidResponse(format!(
-                "Payload size {} exceeds maximum allowed size of {} bytes",
-                length,
-                crate::ipc::protocol::constants::MAX_PAYLOAD_SIZE
-            )));
+            return Err(DiscordIpcError::invalid_response(
+                InvalidResponseKind::PayloadTooLarge,
+                format!(
+                    "Payload size {} exceeds maximum allowed size of {} bytes",
+                    length,
+                    crate::ipc::protocol::constants::MAX_PAYLOAD_SIZE
+                ),
+            ));
         }
 
         let opcode = Opcode::try_from(opcode_raw)?;

--- a/src/async_io/client.rs
+++ b/src/async_io/client.rs
@@ -119,7 +119,7 @@ where
 
         match response.parse_event()? {
             Some(EventData::Ready(ready)) => Ok(Some(ready)),
-            Some(EventData::Unknown { .. }) | None => Ok(None),
+            _ => Ok(None),
         }
     }
 
@@ -146,6 +146,7 @@ where
                 "activity": activity
             }),
             nonce: nonce.clone(),
+            evt: None,
         };
 
         let payload = serde_json::to_value(message)?;
@@ -210,6 +211,7 @@ where
                 "activity": Value::Null
             }),
             nonce: nonce.clone(),
+            evt: None,
         };
 
         let payload = serde_json::to_value(message)?;
@@ -252,6 +254,91 @@ where
         }
 
         Ok(response)
+    }
+
+    /// Subscribe to a Discord IPC event
+    pub async fn subscribe<S: Into<String>>(&mut self, event: S, args: Value) -> Result<()> {
+        let event = event.into();
+        let nonce = generate_nonce("subscribe");
+
+        let message = IpcMessage {
+            cmd: Command::Subscribe,
+            args,
+            nonce: nonce.clone(),
+            evt: Some(event),
+        };
+
+        let payload = serde_json::to_value(message)?;
+        self.send_message(Opcode::Frame, &payload).await?;
+
+        let (_, response) = self.recv_for_nonce(&nonce).await?;
+
+        if let Some(err) = response.get("error") {
+            let code = err.get("code").and_then(|c| c.as_i64()).unwrap_or(0) as i32;
+            let message = err
+                .get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("Unknown error");
+            return Err(DiscordIpcError::discord_error(code, message));
+        }
+
+        Ok(())
+    }
+
+    /// Unsubscribe from a Discord IPC event
+    pub async fn unsubscribe<S: Into<String>>(&mut self, event: S, args: Value) -> Result<()> {
+        let event = event.into();
+        let nonce = generate_nonce("unsubscribe");
+
+        let message = IpcMessage {
+            cmd: Command::Unsubscribe,
+            args,
+            nonce: nonce.clone(),
+            evt: Some(event),
+        };
+
+        let payload = serde_json::to_value(message)?;
+        self.send_message(Opcode::Frame, &payload).await?;
+
+        let (_, response) = self.recv_for_nonce(&nonce).await?;
+
+        if let Some(err) = response.get("error") {
+            let code = err.get("code").and_then(|c| c.as_i64()).unwrap_or(0) as i32;
+            let message = err
+                .get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("Unknown error");
+            return Err(DiscordIpcError::discord_error(code, message));
+        }
+
+        Ok(())
+    }
+
+    /// Waits for the next event asynchronously
+    pub async fn next_event(&mut self) -> Result<EventData> {
+        if let Some(event) = self.take_pending_event()? {
+            return Ok(event);
+        }
+
+        loop {
+            let (opcode, payload) = self.recv_from_connection().await?;
+
+            if !opcode.is_frame_response() {
+                self.pending_messages
+                    .push_back(PendingMessage::new(opcode, payload));
+                continue;
+            }
+
+            let response: IpcResponse = serde_json::from_value(payload.clone())
+                .map_err(DiscordIpcError::DeserializationFailed)?;
+
+            if let Some(event) = response.parse_event()? {
+                return Ok(event);
+            }
+
+            self.pending_messages
+                .push_back(PendingMessage::new(opcode, payload));
+        }
     }
 
     /// Sends a raw IPC message
@@ -396,6 +483,30 @@ where
             .and_then(|n| n.as_str())
             .map(|actual| actual == expected_nonce)
             .unwrap_or(false)
+    }
+
+    fn take_pending_event(&mut self) -> Result<Option<EventData>> {
+        let position = self
+            .pending_messages
+            .iter()
+            .position(|message| Self::value_is_event(&message.payload));
+
+        if let Some(index) = position {
+            if let Some(message) = self.pending_messages.remove(index) {
+                let response: IpcResponse = serde_json::from_value(message.payload)
+                    .map_err(DiscordIpcError::DeserializationFailed)?;
+                return response.parse_event();
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn value_is_event(value: &Value) -> bool {
+        value
+            .get("evt")
+            .and_then(|evt| evt.as_str())
+            .is_some()
     }
 }
 

--- a/src/async_io/client.rs
+++ b/src/async_io/client.rs
@@ -26,6 +26,7 @@ where
     read_buf: BytesMut,
     write_buf: BytesMut,
     pending_messages: VecDeque<PendingMessage>,
+    connected: bool,
 }
 
 impl<T> AsyncDiscordIpcClient<T>
@@ -46,6 +47,7 @@ where
             read_buf: BytesMut::with_capacity(Self::INITIAL_BUFFER_CAPACITY),
             write_buf: BytesMut::with_capacity(Self::INITIAL_BUFFER_CAPACITY),
             pending_messages: VecDeque::new(),
+            connected: false,
         }
     }
 
@@ -60,6 +62,7 @@ where
     /// Returns `DiscordIpcError::HandshakeFailed` if the handshake fails
     pub async fn connect(&mut self) -> Result<Value> {
         self.pending_messages.clear();
+        self.connected = false;
 
         let handshake = HandshakePayload {
             v: constants::IPC_VERSION,
@@ -97,6 +100,7 @@ where
             )));
         }
 
+        self.connected = true;
         Ok(response)
     }
 
@@ -272,6 +276,11 @@ where
     /// Returns a `DiscordIpcError` if deserialization or communication fails
     pub async fn recv_message(&mut self) -> Result<(Opcode, Value)> {
         self.next_message().await
+    }
+
+    /// Returns `true` once a handshake has been successfully completed.
+    pub fn is_connected(&self) -> bool {
+        self.connected
     }
 
     /// Remove pending responses older than the provided `max_age` and return how many were dropped.

--- a/src/async_io/client.rs
+++ b/src/async_io/client.rs
@@ -503,10 +503,7 @@ where
     }
 
     fn value_is_event(value: &Value) -> bool {
-        value
-            .get("evt")
-            .and_then(|evt| evt.as_str())
-            .is_some()
+        value.get("evt").and_then(|evt| evt.as_str()).is_some()
     }
 }
 

--- a/src/async_io/client.rs
+++ b/src/async_io/client.rs
@@ -139,7 +139,7 @@ where
         if let Err(reason) = activity.validate() {
             return Err(DiscordIpcError::invalid_activity(
                 InvalidActivityKind::ValidationFailed,
-                reason,
+                reason.to_string(),
             ));
         }
 

--- a/src/async_io/client.rs
+++ b/src/async_io/client.rs
@@ -12,9 +12,7 @@ use super::traits::ipc_utils::read_u32_le;
 use super::traits::{read_exact, write_all, AsyncRead, AsyncWrite};
 use crate::activity::Activity;
 use crate::debug_println;
-use crate::error::{
-    DiscordIpcError, HandshakeFailureKind, InvalidActivityKind, InvalidResponseKind, Result,
-};
+use crate::error::{DiscordIpcError, HandshakeFailureKind, InvalidResponseKind, Result};
 use crate::ipc::{
     constants, Command, EventData, HandshakePayload, IpcMessage, IpcResponse, Opcode, ReadyEvent,
 };
@@ -136,12 +134,7 @@ where
     /// Returns a `DiscordIpcError` if serialization fails or if Discord returns an error
     pub async fn set_activity(&mut self, activity: &Activity) -> Result<()> {
         // Validate the activity first
-        if let Err(reason) = activity.validate() {
-            return Err(DiscordIpcError::invalid_activity(
-                InvalidActivityKind::ValidationFailed,
-                reason.to_string(),
-            ));
-        }
+        activity.validate()?;
 
         // Generate a cryptographically secure unique nonce for this request
         let nonce = generate_nonce("set-activity");

--- a/src/async_io/smol/mod.rs
+++ b/src/async_io/smol/mod.rs
@@ -401,6 +401,18 @@ pub mod client {
             self.inner.connect().await
         }
 
+        /// Perform handshake and return the typed READY payload when available.
+        pub async fn connect_with_ready(&mut self) -> Result<Option<crate::ipc::ReadyEvent>> {
+            self.inner.connect_with_ready().await
+        }
+
+        /// Parse a raw IPC payload into a READY event if this payload is a READY dispatch.
+        pub fn ready_event_from_payload(
+            payload: &Value,
+        ) -> Result<Option<crate::ipc::ReadyEvent>> {
+            AsyncDiscordIpcClient::<SmolConnection>::ready_event_from_payload(payload)
+        }
+
         /// Returns `true` once a handshake has been successfully completed.
         pub fn is_connected(&self) -> bool {
             self.inner.is_connected()

--- a/src/async_io/smol/mod.rs
+++ b/src/async_io/smol/mod.rs
@@ -10,11 +10,7 @@ use smol::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use smol::net::unix::UnixStream;
 
 #[cfg(windows)]
-use std::fs::File;
-#[cfg(windows)]
-use std::io::{Read, Write};
-#[cfg(windows)]
-use std::sync::{Arc, Mutex};
+use smol::fs::File;
 
 use crate::async_io::traits::{AsyncRead, AsyncWrite};
 use crate::debug_println;
@@ -27,7 +23,7 @@ pub(crate) enum SmolConnection {
     Unix(UnixStream),
 
     #[cfg(windows)]
-    Windows(Arc<Mutex<File>>),
+    Windows(File),
 }
 
 impl SmolConnection {
@@ -101,44 +97,16 @@ impl SmolConnection {
     #[cfg(unix)]
     /// Connect to Discord IPC socket using auto-discovery
     async fn connect_unix_auto() -> Result<Self> {
-        // Try environment variables in order of preference
-        let env_keys = ["XDG_RUNTIME_DIR", "TMPDIR", "TMP", "TEMP"];
-        let mut directories = Vec::new();
-
-        for env_key in &env_keys {
-            if let Ok(dir) = std::env::var(env_key) {
-                directories.push(dir.clone());
-
-                // Also check Flatpak Discord path if XDG_RUNTIME_DIR is set
-                if env_key == &"XDG_RUNTIME_DIR" {
-                    directories.push(format!("{}/app/com.discordapp.Discord", dir));
-                }
-            }
-        }
-
-        // Fallback to /run/user/{uid} if no env vars found
-        if directories.is_empty() {
-            let uid = unsafe { libc::getuid() };
-            directories.push(format!("/run/user/{}", uid));
-            // Also try Flatpak path as fallback
-            directories.push(format!("/run/user/{}/app/com.discordapp.Discord", uid));
-        }
-
-        // Try each directory with each socket number
         let mut last_error = None;
 
-        for dir in &directories {
-            for i in 0..constants::MAX_IPC_SOCKETS {
-                let socket_path = format!("{}/{}{}", dir, constants::IPC_SOCKET_PREFIX, i);
-
-                match UnixStream::connect(&socket_path).await {
-                    Ok(stream) => {
-                        return Ok(Self::Unix(stream));
-                    }
-                    Err(err) => {
-                        last_error = Some(err);
-                        continue;
-                    }
+        for socket_path in crate::ipc::discovery::get_socket_paths() {
+            match UnixStream::connect(&socket_path).await {
+                Ok(stream) => {
+                    return Ok(Self::Unix(stream));
+                }
+                Err(err) => {
+                    last_error = Some(err);
+                    continue;
                 }
             }
         }
@@ -180,7 +148,7 @@ impl SmolConnection {
                 .await
                 .map_err(DiscordIpcError::ConnectionFailed)?;
 
-                Ok(Self::Windows(Arc::new(Mutex::new(file))))
+                Ok(Self::Windows(File::from(file)))
             }
         }
     }
@@ -194,9 +162,7 @@ impl SmolConnection {
 
         let mut last_error = None;
 
-        for i in 0..constants::MAX_IPC_SOCKETS {
-            let pipe_path = format!(r"\\.\pipe\discord-ipc-{}", i);
-
+        for pipe_path in crate::ipc::discovery::get_pipe_paths() {
             debug_println!("Attempting to connect to Windows named pipe: {}", pipe_path);
 
             // Clone pipe_path for the closure
@@ -216,7 +182,7 @@ impl SmolConnection {
             match result {
                 Ok(file) => {
                     debug_println!("Successfully opened named pipe: {}", pipe_path);
-                    return Ok(Self::Windows(Arc::new(Mutex::new(file))));
+                    return Ok(Self::Windows(File::from(file)));
                 }
                 Err(err) => {
                     debug_println!("Failed to connect to named pipe {}: {}", pipe_path, err);
@@ -251,37 +217,15 @@ impl AsyncRead for SmolConnection {
         Box::pin(async move {
             match self {
                 #[cfg(unix)]
-                Self::Unix(stream) => stream.read(buf).await,
+                Self::Unix(stream) => {
+                    use smol::io::AsyncReadExt;
+                    stream.read(buf).await
+                }
 
                 #[cfg(windows)]
                 Self::Windows(pipe) => {
-                    // Clone the Arc to pass into the blocking task
-                    let pipe_clone = Arc::clone(pipe);
-                    let buf_len = buf.len();
-
-                    // Use smol's unblock to handle synchronous I/O in async context
-                    let result = smol::unblock(move || {
-                        let mut local_buf = vec![0u8; buf_len];
-                        let mut file = match pipe_clone.lock().map_err(|e| {
-                            io::Error::new(io::ErrorKind::Other, format!("Mutex poisoned: {}", e))
-                        }) {
-                            Ok(f) => f,
-                            Err(e) => return Err(e),
-                        };
-                        match file.read(&mut local_buf) {
-                            Ok(n) => Ok((n, local_buf)),
-                            Err(e) => Err(e),
-                        }
-                    })
-                    .await;
-
-                    match result {
-                        Ok((n, data)) => {
-                            buf[..n].copy_from_slice(&data[..n]);
-                            Ok(n)
-                        }
-                        Err(e) => Err(e),
-                    }
+                    use smol::io::AsyncReadExt;
+                    pipe.read(buf).await
                 }
             }
         })
@@ -296,28 +240,15 @@ impl AsyncWrite for SmolConnection {
         Box::pin(async move {
             match self {
                 #[cfg(unix)]
-                Self::Unix(stream) => stream.write(buf).await,
+                Self::Unix(stream) => {
+                    use smol::io::AsyncWriteExt;
+                    stream.write(buf).await
+                }
 
                 #[cfg(windows)]
                 Self::Windows(pipe) => {
-                    // Clone the Arc to pass into the blocking task
-                    let pipe_clone = Arc::clone(pipe);
-                    let data = buf.to_vec();
-
-                    // Use smol's unblock to handle synchronous I/O in async context
-                    smol::unblock(move || {
-                        let mut file = match pipe_clone.lock() {
-                            Ok(f) => f,
-                            Err(e) => {
-                                return Err(io::Error::new(
-                                    io::ErrorKind::Other,
-                                    format!("Mutex poisoned: {}", e),
-                                ));
-                            }
-                        };
-                        file.write(&data)
-                    })
-                    .await
+                    use smol::io::AsyncWriteExt;
+                    pipe.write(buf).await
                 }
             }
         })
@@ -327,26 +258,15 @@ impl AsyncWrite for SmolConnection {
         Box::pin(async move {
             match self {
                 #[cfg(unix)]
-                Self::Unix(stream) => stream.flush().await,
+                Self::Unix(stream) => {
+                    use smol::io::AsyncWriteExt;
+                    stream.flush().await
+                }
 
                 #[cfg(windows)]
                 Self::Windows(pipe) => {
-                    // Clone the Arc to pass into the blocking task
-                    let pipe_clone = Arc::clone(pipe);
-
-                    smol::unblock(move || {
-                        let mut file = match pipe_clone.lock() {
-                            Ok(f) => f,
-                            Err(e) => {
-                                return Err(io::Error::new(
-                                    io::ErrorKind::Other,
-                                    format!("Mutex poisoned: {}", e),
-                                ));
-                            }
-                        };
-                        file.flush()
-                    })
-                    .await
+                    use smol::io::AsyncWriteExt;
+                    pipe.flush().await
                 }
             }
         })
@@ -424,6 +344,25 @@ pub mod client {
         /// Clears Discord Rich Presence activity
         pub async fn clear_activity(&mut self) -> Result<Value> {
             self.inner.clear_activity().await
+        }
+
+        /// Subscribe to a Discord IPC event.
+        pub async fn subscribe<S: Into<String>>(&mut self, event: S, args: Value) -> Result<()> {
+            self.inner.subscribe(event, args).await
+        }
+
+        /// Unsubscribe from a Discord IPC event.
+        pub async fn unsubscribe<S: Into<String>>(
+            &mut self,
+            event: S,
+            args: Value,
+        ) -> Result<()> {
+            self.inner.unsubscribe(event, args).await
+        }
+
+        /// Wait for the next IPC event.
+        pub async fn next_event(&mut self) -> Result<crate::ipc::EventData> {
+            self.inner.next_event().await
         }
 
         /// Reconnect to Discord IPC

--- a/src/async_io/smol/mod.rs
+++ b/src/async_io/smol/mod.rs
@@ -352,11 +352,7 @@ pub mod client {
         }
 
         /// Unsubscribe from a Discord IPC event.
-        pub async fn unsubscribe<S: Into<String>>(
-            &mut self,
-            event: S,
-            args: Value,
-        ) -> Result<()> {
+        pub async fn unsubscribe<S: Into<String>>(&mut self, event: S, args: Value) -> Result<()> {
             self.inner.unsubscribe(event, args).await
         }
 

--- a/src/async_io/smol/mod.rs
+++ b/src/async_io/smol/mod.rs
@@ -401,6 +401,11 @@ pub mod client {
             self.inner.connect().await
         }
 
+        /// Returns `true` once a handshake has been successfully completed.
+        pub fn is_connected(&self) -> bool {
+            self.inner.is_connected()
+        }
+
         /// Sets Discord Rich Presence activity
         pub async fn set_activity(&mut self, activity: &crate::activity::Activity) -> Result<()> {
             self.inner.set_activity(activity).await

--- a/src/async_io/smol/mod.rs
+++ b/src/async_io/smol/mod.rs
@@ -407,9 +407,7 @@ pub mod client {
         }
 
         /// Parse a raw IPC payload into a READY event if this payload is a READY dispatch.
-        pub fn ready_event_from_payload(
-            payload: &Value,
-        ) -> Result<Option<crate::ipc::ReadyEvent>> {
+        pub fn ready_event_from_payload(payload: &Value) -> Result<Option<crate::ipc::ReadyEvent>> {
             AsyncDiscordIpcClient::<SmolConnection>::ready_event_from_payload(payload)
         }
 

--- a/src/async_io/tokio/mod.rs
+++ b/src/async_io/tokio/mod.rs
@@ -281,11 +281,7 @@ pub mod client {
         }
 
         /// Unsubscribe from a Discord IPC event.
-        pub async fn unsubscribe<S: Into<String>>(
-            &mut self,
-            event: S,
-            args: Value,
-        ) -> Result<()> {
+        pub async fn unsubscribe<S: Into<String>>(&mut self, event: S, args: Value) -> Result<()> {
             self.inner.unsubscribe(event, args).await
         }
 

--- a/src/async_io/tokio/mod.rs
+++ b/src/async_io/tokio/mod.rs
@@ -280,6 +280,18 @@ pub mod client {
             self.inner.connect().await
         }
 
+        /// Perform handshake and return the typed READY payload when available.
+        pub async fn connect_with_ready(&mut self) -> Result<Option<crate::ipc::ReadyEvent>> {
+            self.inner.connect_with_ready().await
+        }
+
+        /// Parse a raw IPC payload into a READY event if this payload is a READY dispatch.
+        pub fn ready_event_from_payload(
+            payload: &Value,
+        ) -> Result<Option<crate::ipc::ReadyEvent>> {
+            AsyncDiscordIpcClient::<TokioConnection>::ready_event_from_payload(payload)
+        }
+
         /// Returns `true` once a handshake has been successfully completed.
         pub fn is_connected(&self) -> bool {
             self.inner.is_connected()

--- a/src/async_io/tokio/mod.rs
+++ b/src/async_io/tokio/mod.rs
@@ -286,9 +286,7 @@ pub mod client {
         }
 
         /// Parse a raw IPC payload into a READY event if this payload is a READY dispatch.
-        pub fn ready_event_from_payload(
-            payload: &Value,
-        ) -> Result<Option<crate::ipc::ReadyEvent>> {
+        pub fn ready_event_from_payload(payload: &Value) -> Result<Option<crate::ipc::ReadyEvent>> {
             AsyncDiscordIpcClient::<TokioConnection>::ready_event_from_payload(payload)
         }
 

--- a/src/async_io/tokio/mod.rs
+++ b/src/async_io/tokio/mod.rs
@@ -280,6 +280,11 @@ pub mod client {
             self.inner.connect().await
         }
 
+        /// Returns `true` once a handshake has been successfully completed.
+        pub fn is_connected(&self) -> bool {
+            self.inner.is_connected()
+        }
+
         /// Sets Discord Rich Presence activity
         pub async fn set_activity(&mut self, activity: &crate::activity::Activity) -> Result<()> {
             self.inner.set_activity(activity).await

--- a/src/async_io/tokio/mod.rs
+++ b/src/async_io/tokio/mod.rs
@@ -74,44 +74,16 @@ impl TokioConnection {
     #[cfg(unix)]
     /// Connect to Discord IPC socket using auto-discovery
     async fn connect_unix_auto() -> Result<Self> {
-        // Try environment variables in order of preference
-        let env_keys = ["XDG_RUNTIME_DIR", "TMPDIR", "TMP", "TEMP"];
-        let mut directories = Vec::new();
-
-        for env_key in &env_keys {
-            if let Ok(dir) = std::env::var(env_key) {
-                directories.push(dir.clone());
-
-                // Also check Flatpak Discord path if XDG_RUNTIME_DIR is set
-                if env_key == &"XDG_RUNTIME_DIR" {
-                    directories.push(format!("{}/app/com.discordapp.Discord", dir));
-                }
-            }
-        }
-
-        // Fallback to /run/user/{uid} if no env vars found
-        if directories.is_empty() {
-            let uid = unsafe { libc::getuid() };
-            directories.push(format!("/run/user/{}", uid));
-            // Also try Flatpak path as fallback
-            directories.push(format!("/run/user/{}/app/com.discordapp.Discord", uid));
-        }
-
-        // Try each directory with each socket number
         let mut last_error = None;
 
-        for dir in &directories {
-            for i in 0..constants::MAX_IPC_SOCKETS {
-                let socket_path = format!("{}/{}{}", dir, constants::IPC_SOCKET_PREFIX, i);
-
-                match UnixStream::connect(&socket_path).await {
-                    Ok(stream) => {
-                        return Ok(Self::Unix(stream));
-                    }
-                    Err(err) => {
-                        last_error = Some(err);
-                        continue;
-                    }
+        for socket_path in crate::ipc::discovery::get_socket_paths() {
+            match UnixStream::connect(&socket_path).await {
+                Ok(stream) => {
+                    return Ok(Self::Unix(stream));
+                }
+                Err(err) => {
+                    last_error = Some(err);
+                    continue;
                 }
             }
         }
@@ -149,9 +121,7 @@ impl TokioConnection {
     async fn connect_windows_auto() -> Result<Self> {
         let mut last_error = None;
 
-        for i in 0..constants::MAX_IPC_SOCKETS {
-            let pipe_path = format!(r"\\.\pipe\discord-ipc-{}", i);
-
+        for pipe_path in crate::ipc::discovery::get_pipe_paths() {
             // Try to open the named pipe
             debug_println!("Attempting to connect to Windows named pipe: {}", pipe_path);
             match ClientOptions::new().open(pipe_path.clone()) {
@@ -303,6 +273,25 @@ pub mod client {
         /// Clears Discord Rich Presence activity
         pub async fn clear_activity(&mut self) -> Result<Value> {
             self.inner.clear_activity().await
+        }
+
+        /// Subscribe to a Discord IPC event.
+        pub async fn subscribe<S: Into<String>>(&mut self, event: S, args: Value) -> Result<()> {
+            self.inner.subscribe(event, args).await
+        }
+
+        /// Unsubscribe from a Discord IPC event.
+        pub async fn unsubscribe<S: Into<String>>(
+            &mut self,
+            event: S,
+            args: Value,
+        ) -> Result<()> {
+            self.inner.unsubscribe(event, args).await
+        }
+
+        /// Wait for the next IPC event.
+        pub async fn next_event(&mut self) -> Result<crate::ipc::EventData> {
+            self.inner.next_event().await
         }
 
         /// Reconnect to Discord IPC

--- a/src/error.rs
+++ b/src/error.rs
@@ -59,6 +59,37 @@ pub enum ErrorCategory {
     Other,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum HandshakeFailureKind {
+    InvalidErrorPayload,
+    UnexpectedOpcode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum InvalidResponseKind {
+    UnexpectedOpcode,
+    InvalidErrorPayload,
+    NonceMismatch,
+    PayloadTooLarge,
+    MissingEventData,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ProtocolViolationKind {
+    InvalidOpcodeValue,
+    PayloadTooLarge,
+    Other,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum InvalidActivityKind {
+    ValidationFailed,
+}
+
 impl Display for ErrorCategory {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -155,12 +186,18 @@ pub enum DiscordIpcError {
     DeserializationFailed(#[source] serde_json::Error),
 
     /// Received an invalid or unexpected response from Discord
-    #[error("Invalid response from Discord: {0}")]
-    InvalidResponse(String),
+    #[error("Invalid response from Discord ({kind:?}){details}")]
+    InvalidResponse {
+        kind: InvalidResponseKind,
+        details: ErrorDetail,
+    },
 
     /// Handshake with Discord failed
-    #[error("Handshake failed: {0}")]
-    HandshakeFailed(String),
+    #[error("Handshake failed ({kind:?}){details}")]
+    HandshakeFailed {
+        kind: HandshakeFailureKind,
+        details: ErrorDetail,
+    },
 
     /// Socket connection was closed unexpectedly
     #[error("Socket connection was closed unexpectedly")]
@@ -171,9 +208,10 @@ pub enum DiscordIpcError {
     InvalidOpcode(u32),
 
     /// Protocol violation occurred during IPC communication
-    #[error("Protocol violation: {message}")]
+    #[error("Protocol violation ({kind:?}){details}")]
     ProtocolViolation {
-        message: String,
+        kind: ProtocolViolationKind,
+        details: ErrorDetail,
         context: ProtocolContext,
     },
 
@@ -185,8 +223,11 @@ pub enum DiscordIpcError {
         message: String,
     },
 
-    #[error("Invalid activity: {0}")]
-    InvalidActivity(String),
+    #[error("Invalid activity ({kind:?}){details}")]
+    InvalidActivity {
+        kind: InvalidActivityKind,
+        details: ErrorDetail,
+    },
 
     /// System time error (e.g., time before UNIX epoch)
     #[error("System time error: {0}")]
@@ -206,14 +247,14 @@ impl DiscordIpcError {
                 ErrorCategory::Serialization
             }
 
-            Self::InvalidResponse(_)
-            | Self::HandshakeFailed(_)
+            Self::InvalidResponse { .. }
+            | Self::HandshakeFailed { .. }
             | Self::InvalidOpcode(_)
             | Self::ProtocolViolation { .. } => ErrorCategory::Protocol,
 
             Self::DiscordError { .. } => ErrorCategory::Application,
 
-            Self::InvalidActivity(_) | Self::SystemTimeError(_) => ErrorCategory::Other,
+            Self::InvalidActivity { .. } | Self::SystemTimeError(_) => ErrorCategory::Other,
         }
     }
 
@@ -226,9 +267,30 @@ impl DiscordIpcError {
             self,
             Self::ConnectionTimeout { .. }
                 | Self::SocketClosed
-                | Self::InvalidResponse(_)
+                | Self::InvalidResponse { .. }
                 | Self::SocketDiscoveryFailed { .. }
         )
+    }
+
+    pub fn invalid_response(kind: InvalidResponseKind, details: impl Into<ErrorDetail>) -> Self {
+        Self::InvalidResponse {
+            kind,
+            details: details.into(),
+        }
+    }
+
+    pub fn handshake_failed(kind: HandshakeFailureKind, details: impl Into<ErrorDetail>) -> Self {
+        Self::HandshakeFailed {
+            kind,
+            details: details.into(),
+        }
+    }
+
+    pub fn invalid_activity(kind: InvalidActivityKind, details: impl Into<ErrorDetail>) -> Self {
+        Self::InvalidActivity {
+            kind,
+            details: details.into(),
+        }
     }
 
     pub fn discord_error(code: i32, message: impl Into<String>) -> Self {
@@ -255,10 +317,52 @@ impl DiscordIpcError {
     }
 
     /// Create a ProtocolViolation error with message and context
-    pub fn protocol_violation(message: impl Into<String>, context: ProtocolContext) -> Self {
+    pub fn protocol_violation(
+        kind: ProtocolViolationKind,
+        details: impl Into<ErrorDetail>,
+        context: ProtocolContext,
+    ) -> Self {
         Self::ProtocolViolation {
-            message: message.into(),
+            kind,
+            details: details.into(),
             context,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ErrorDetail(Option<String>);
+
+impl ErrorDetail {
+    pub fn new(details: impl Into<Option<String>>) -> Self {
+        Self(details.into())
+    }
+}
+
+impl From<String> for ErrorDetail {
+    fn from(value: String) -> Self {
+        Self(Some(value))
+    }
+}
+
+impl From<&str> for ErrorDetail {
+    fn from(value: &str) -> Self {
+        Self(Some(value.to_string()))
+    }
+}
+
+impl From<Option<String>> for ErrorDetail {
+    fn from(value: Option<String>) -> Self {
+        Self(value)
+    }
+}
+
+impl Display for ErrorDetail {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(detail) = &self.0 {
+            write!(f, ": {detail}")
+        } else {
+            Ok(())
         }
     }
 }
@@ -402,7 +506,10 @@ mod tests {
         assert!(conn_err.is_connection_error());
         assert!(conn_err.is_recoverable());
 
-        let proto_err = DiscordIpcError::InvalidResponse("oops".into());
+        let proto_err = DiscordIpcError::invalid_response(
+            InvalidResponseKind::UnexpectedOpcode,
+            Some("oops".to_string()),
+        );
         assert_eq!(proto_err.category(), ErrorCategory::Protocol);
         assert!(proto_err.is_recoverable());
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -85,12 +85,6 @@ pub enum ProtocolViolationKind {
     Other,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum InvalidActivityKind {
-    ValidationFailed,
-}
-
 impl Display for ErrorCategory {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -224,11 +218,8 @@ pub enum DiscordIpcError {
         message: String,
     },
 
-    #[error("Invalid activity ({kind:?}){details}")]
-    InvalidActivity {
-        kind: InvalidActivityKind,
-        details: ErrorDetail,
-    },
+    #[error("Invalid activity: {0}")]
+    InvalidActivity(#[from] crate::activity::ActivityValidationError),
 
     /// System time error (e.g., time before UNIX epoch)
     #[error("System time error: {0}")]
@@ -255,7 +246,7 @@ impl DiscordIpcError {
 
             Self::DiscordError { .. } => ErrorCategory::Application,
 
-            Self::InvalidActivity { .. } | Self::SystemTimeError(_) => ErrorCategory::Other,
+            Self::InvalidActivity(_) | Self::SystemTimeError(_) => ErrorCategory::Other,
         }
     }
 
@@ -282,13 +273,6 @@ impl DiscordIpcError {
 
     pub fn handshake_failed(kind: HandshakeFailureKind, details: impl Into<ErrorDetail>) -> Self {
         Self::HandshakeFailed {
-            kind,
-            details: details.into(),
-        }
-    }
-
-    pub fn invalid_activity(kind: InvalidActivityKind, details: impl Into<ErrorDetail>) -> Self {
-        Self::InvalidActivity {
             kind,
             details: details.into(),
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 use std::fmt::{self, Display};
 use std::io;
+use std::time::SystemTimeError as StdSystemTimeError;
 use thiserror::Error;
 
 /// Context information for protocol violations
@@ -231,7 +232,7 @@ pub enum DiscordIpcError {
 
     /// System time error (e.g., time before UNIX epoch)
     #[error("System time error: {0}")]
-    SystemTimeError(String),
+    SystemTimeError(#[source] StdSystemTimeError),
 }
 
 impl DiscordIpcError {

--- a/src/ipc/connection.rs
+++ b/src/ipc/connection.rs
@@ -11,7 +11,7 @@ use std::fs::OpenOptions;
 #[cfg(windows)]
 use std::io::{BufReader, BufWriter};
 
-use crate::error::{DiscordIpcError, ProtocolContext, Result};
+use crate::error::{DiscordIpcError, ProtocolContext, ProtocolViolationKind, Result};
 use crate::ipc::protocol::{constants, Opcode};
 
 /// Configuration for selecting which Discord IPC pipe to connect to
@@ -469,6 +469,7 @@ impl IpcConnection {
         if length > constants::MAX_PAYLOAD_SIZE {
             let context = ProtocolContext::with_payload(opcode_raw, length as usize);
             return Err(DiscordIpcError::protocol_violation(
+                ProtocolViolationKind::PayloadTooLarge,
                 format!(
                     "Payload size {} exceeds maximum allowed size of {} bytes",
                     length,

--- a/src/ipc/connection.rs
+++ b/src/ipc/connection.rs
@@ -121,10 +121,7 @@ impl IpcConnection {
                     .unwrap_or(0) as u8;
 
                 drop(file); // Close the test connection
-                pipes.push(DiscoveredPipe {
-                    pipe_number,
-                    path,
-                });
+                pipes.push(DiscoveredPipe { pipe_number, path });
             }
         }
 

--- a/src/ipc/connection.rs
+++ b/src/ipc/connection.rs
@@ -84,53 +84,12 @@ impl IpcConnection {
         }
     }
 
-    // Returns the current users UID on unix based systems
-    #[cfg(unix)]
-    /// Returns the current user's UID on Unix-based systems.
-    ///
-    /// Safety: Calling `libc::getuid()` is always safe per POSIX.
-    fn current_uid() -> u32 {
-        unsafe { libc::getuid() }
-    }
-    /// Discovers potential base directories where IPC sockets may exist
-    /// Check environment variables
-    /// - `XDG_RUNTIME_DIR`
-    /// - `TMPDIR`
-    /// - `TMP`
-    /// - `TEMP`
-    /// - `tmp`
-    /// - `XDG_RUNTIME_DIR/app/com.discordapp.Discord` (Flatpak specific)
-    /// - `/run/user/{UID}` (if `XDG_RUNTIME_DIR` is not set)
-    /// - `/run/user/{UID}/app/com.discordapp.Discord` (Flatpak fallback)
-    #[cfg(unix)]
-    fn candidate_ipc_dir() -> Vec<String> {
-        let env_keys = ["XDG_RUNTIME_DIR", "TMPDIR", "TMP", "TEMP", "tmp"];
-        let mut directories = Vec::new();
-        for key in &env_keys {
-            if let Ok(dir) = std::env::var(key) {
-                directories.push(dir.clone());
-
-                // Also check Flatpak Discord path if XDG_RUNTIME_DIR is set
-                if key == &"XDG_RUNTIME_DIR" {
-                    directories.push(format!("{}/app/com.discordapp.Discord", dir));
-                }
-            }
-        }
-        if directories.is_empty() {
-            let uid = Self::current_uid();
-            directories.push(format!("/run/user/{}", uid));
-            // Also try Flatpak path as fallback
-            directories.push(format!("/run/user/{}/app/com.discordapp.Discord", uid));
-        }
-
-        directories
-    }
     #[cfg(unix)]
     fn discover_pipes_unix() -> Vec<DiscoveredPipe> {
         let mut pipes = Vec::new();
 
         // Try each directory with each socket number
-        for dir in Self::candidate_ipc_dir() {
+        for dir in crate::ipc::discovery::candidate_ipc_directories() {
             for i in 0..constants::MAX_IPC_SOCKETS {
                 let socket_path = format!("{}/{}{}", dir, constants::IPC_SOCKET_PREFIX, i);
 
@@ -152,15 +111,19 @@ impl IpcConnection {
     fn discover_pipes_windows() -> Vec<DiscoveredPipe> {
         let mut pipes = Vec::new();
 
-        for i in 0..constants::MAX_IPC_SOCKETS {
-            let pipe_path = format!(r"\\?\pipe\discord-ipc-{}", i);
-
+        for path in crate::ipc::discovery::get_pipe_paths() {
             // Try to open the named pipe to check if it exists
-            if let Ok(file) = OpenOptions::new().read(true).write(true).open(&pipe_path) {
+            if let Ok(file) = OpenOptions::new().read(true).write(true).open(&path) {
+                let pipe_number = path
+                    .chars()
+                    .last()
+                    .and_then(|c| c.to_digit(10))
+                    .unwrap_or(0) as u8;
+
                 drop(file); // Close the test connection
                 pipes.push(DiscoveredPipe {
-                    pipe_number: i,
-                    path: pipe_path,
+                    pipe_number,
+                    path,
                 });
             }
         }
@@ -306,7 +269,7 @@ impl IpcConnection {
         let mut last_error = None;
         let mut attempted_paths = Vec::new();
 
-        for dir in Self::candidate_ipc_dir() {
+        for dir in crate::ipc::discovery::candidate_ipc_directories() {
             for i in 0..constants::MAX_IPC_SOCKETS {
                 let socket_path = format!("{}/{}{}", dir, constants::IPC_SOCKET_PREFIX, i);
                 attempted_paths.push(socket_path.clone());
@@ -373,12 +336,11 @@ impl IpcConnection {
         let mut last_error = None;
         let mut attempted_paths = Vec::new();
 
-        for i in 0..constants::MAX_IPC_SOCKETS {
-            let pipe_path = format!(r"\\?\pipe\discord-ipc-{}", i);
-            attempted_paths.push(pipe_path.clone());
+        for path in crate::ipc::discovery::get_pipe_paths() {
+            attempted_paths.push(path.clone());
 
             // Try to open the named pipe
-            match OpenOptions::new().read(true).write(true).open(&pipe_path) {
+            match OpenOptions::new().read(true).write(true).open(&path) {
                 Ok(file) => {
                     // Clone the file handle for reader and writer
                     match file.try_clone() {

--- a/src/ipc/discovery.rs
+++ b/src/ipc/discovery.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2025-2026 Sreehari Anil and project contributors
+
 use crate::ipc::protocol::constants;
 
 /// Returns the current user's UID on Unix-based systems.

--- a/src/ipc/discovery.rs
+++ b/src/ipc/discovery.rs
@@ -20,7 +20,7 @@ pub fn candidate_ipc_directories() -> Vec<String> {
             if key == &"XDG_RUNTIME_DIR" {
                 // Flatpak
                 directories.push(format!("{}/app/com.discordapp.Discord", dir));
-                
+
                 // Snap (can be snap.discord, snap.discord-canary, etc.)
                 if let Ok(entries) = std::fs::read_dir(&dir) {
                     for entry in entries.flatten() {
@@ -51,7 +51,7 @@ pub fn candidate_ipc_directories() -> Vec<String> {
     if !directories.contains(&flatpak_fallback) {
         directories.push(flatpak_fallback);
     }
-    
+
     // Snap fallback scan
     let base_run_user = format!("/run/user/{}", uid);
     if let Ok(entries) = std::fs::read_dir(&base_run_user) {

--- a/src/ipc/discovery.rs
+++ b/src/ipc/discovery.rs
@@ -1,0 +1,96 @@
+use crate::ipc::protocol::constants;
+
+/// Returns the current user's UID on Unix-based systems.
+#[cfg(unix)]
+fn current_uid() -> u32 {
+    unsafe { libc::getuid() }
+}
+
+/// Discovers potential base directories where Discord IPC sockets may exist on Unix systems.
+#[cfg(unix)]
+pub fn candidate_ipc_directories() -> Vec<String> {
+    let env_keys = ["XDG_RUNTIME_DIR", "TMPDIR", "TMP", "TEMP", "tmp"];
+    let mut directories = Vec::new();
+
+    for key in &env_keys {
+        if let Ok(dir) = std::env::var(key) {
+            directories.push(dir.clone());
+
+            // Check specialized paths if XDG_RUNTIME_DIR is set
+            if key == &"XDG_RUNTIME_DIR" {
+                // Flatpak
+                directories.push(format!("{}/app/com.discordapp.Discord", dir));
+                
+                // Snap (can be snap.discord, snap.discord-canary, etc.)
+                if let Ok(entries) = std::fs::read_dir(&dir) {
+                    for entry in entries.flatten() {
+                        if let Ok(name) = entry.file_name().into_string() {
+                            if name.starts_with("snap.discord") {
+                                if let Ok(metadata) = entry.metadata() {
+                                    if metadata.is_dir() {
+                                        directories.push(format!("{}/{}", dir, name));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Fallback to /run/user/{uid} if directories list is still thin or to ensure coverage
+    let uid = current_uid();
+    let run_user_dir = format!("/run/user/{}", uid);
+    if !directories.contains(&run_user_dir) {
+        directories.push(run_user_dir.clone());
+    }
+
+    // Fallback specialized paths for /run/user/{uid}
+    let flatpak_fallback = format!("/run/user/{}/app/com.discordapp.Discord", uid);
+    if !directories.contains(&flatpak_fallback) {
+        directories.push(flatpak_fallback);
+    }
+    
+    // Snap fallback scan
+    let base_run_user = format!("/run/user/{}", uid);
+    if let Ok(entries) = std::fs::read_dir(&base_run_user) {
+        for entry in entries.flatten() {
+            if let Ok(name) = entry.file_name().into_string() {
+                if name.starts_with("snap.discord") {
+                    if let Ok(metadata) = entry.metadata() {
+                        if metadata.is_dir() {
+                            let path = format!("{}/{}", base_run_user, name);
+                            if !directories.contains(&path) {
+                                directories.push(path);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    directories
+}
+
+/// Returns a list of all potential Discord IPC socket/pipe paths to check.
+#[cfg(unix)]
+pub fn get_socket_paths() -> Vec<String> {
+    let mut paths = Vec::new();
+    for dir in candidate_ipc_directories() {
+        for i in 0..constants::MAX_IPC_SOCKETS {
+            paths.push(format!("{}/{}{}", dir, constants::IPC_SOCKET_PREFIX, i));
+        }
+    }
+    paths
+}
+
+#[cfg(windows)]
+pub fn get_pipe_paths() -> Vec<String> {
+    let mut paths = Vec::new();
+    for i in 0..constants::MAX_IPC_SOCKETS {
+        paths.push(format!(r"\\.\pipe\discord-ipc-{}", i));
+    }
+    paths
+}

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -1,5 +1,7 @@
 pub mod connection;
+pub mod discovery;
 pub mod protocol;
 
 pub use connection::*;
+pub use discovery::*;
 pub use protocol::*;

--- a/src/ipc/protocol.rs
+++ b/src/ipc/protocol.rs
@@ -18,10 +18,39 @@ pub struct ReadyEvent {
     pub user: Option<PartialUser>,
 }
 
+/// Payload for ACTIVITY_JOIN event
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActivityJoinEvent {
+    pub secret: String,
+}
+
+/// Payload for ACTIVITY_SPECTATE event
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActivitySpectateEvent {
+    pub secret: String,
+}
+
+/// Payload for ACTIVITY_JOIN_REQUEST event
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActivityJoinRequestEvent {
+    pub user: PartialUser,
+}
+
+/// Payload for ERROR event from Discord
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrorEvent {
+    pub code: i32,
+    pub message: String,
+}
+
 /// Parsed Discord IPC events.
 #[derive(Debug, Clone)]
 pub enum EventData {
     Ready(ReadyEvent),
+    ActivityJoin(ActivityJoinEvent),
+    ActivitySpectate(ActivitySpectateEvent),
+    ActivityJoinRequest(ActivityJoinRequestEvent),
+    Error(ErrorEvent),
     Unknown { name: String, data: Option<Value> },
 }
 
@@ -96,6 +125,8 @@ pub struct IpcMessage {
     pub cmd: Command,
     pub args: Value,
     pub nonce: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evt: Option<String>,
 }
 
 /// Handshake payload
@@ -132,6 +163,50 @@ impl IpcResponse {
                 let ready = serde_json::from_value::<ReadyEvent>(data)
                     .map_err(DiscordIpcError::DeserializationFailed)?;
                 Ok(Some(EventData::Ready(ready)))
+            }
+            "ACTIVITY_JOIN" => {
+                let data = self.data.clone().ok_or_else(|| {
+                    DiscordIpcError::invalid_response(
+                        InvalidResponseKind::MissingEventData,
+                        "ACTIVITY_JOIN event is missing data".to_string(),
+                    )
+                })?;
+                let event = serde_json::from_value::<ActivityJoinEvent>(data)
+                    .map_err(DiscordIpcError::DeserializationFailed)?;
+                Ok(Some(EventData::ActivityJoin(event)))
+            }
+            "ACTIVITY_SPECTATE" => {
+                let data = self.data.clone().ok_or_else(|| {
+                    DiscordIpcError::invalid_response(
+                        InvalidResponseKind::MissingEventData,
+                        "ACTIVITY_SPECTATE event is missing data".to_string(),
+                    )
+                })?;
+                let event = serde_json::from_value::<ActivitySpectateEvent>(data)
+                    .map_err(DiscordIpcError::DeserializationFailed)?;
+                Ok(Some(EventData::ActivitySpectate(event)))
+            }
+            "ACTIVITY_JOIN_REQUEST" => {
+                let data = self.data.clone().ok_or_else(|| {
+                    DiscordIpcError::invalid_response(
+                        InvalidResponseKind::MissingEventData,
+                        "ACTIVITY_JOIN_REQUEST event is missing data".to_string(),
+                    )
+                })?;
+                let event = serde_json::from_value::<ActivityJoinRequestEvent>(data)
+                    .map_err(DiscordIpcError::DeserializationFailed)?;
+                Ok(Some(EventData::ActivityJoinRequest(event)))
+            }
+            "ERROR" => {
+                let data = self.data.clone().ok_or_else(|| {
+                    DiscordIpcError::invalid_response(
+                        InvalidResponseKind::MissingEventData,
+                        "ERROR event is missing data".to_string(),
+                    )
+                })?;
+                let event = serde_json::from_value::<ErrorEvent>(data)
+                    .map_err(DiscordIpcError::DeserializationFailed)?;
+                Ok(Some(EventData::Error(event)))
             }
             other => Ok(Some(EventData::Unknown {
                 name: other.to_string(),
@@ -340,6 +415,7 @@ mod tests {
             cmd: Command::SetActivity,
             args: serde_json::json!({"foo": "bar"}),
             nonce: "1234".to_string(),
+            evt: None,
         };
 
         let json = serde_json::to_string(&message).expect("serialize message");
@@ -351,5 +427,40 @@ mod tests {
             deserialized.args.get("foo").and_then(Value::as_str),
             Some("bar")
         );
+    }
+
+    #[test]
+    fn parse_activity_join_event() {
+        let response = IpcResponse {
+            cmd: Some("DISPATCH".to_string()),
+            data: Some(serde_json::json!({"secret": "join_me"})),
+            evt: Some("ACTIVITY_JOIN".to_string()),
+            nonce: None,
+        };
+
+        let event = response.parse_event().unwrap().unwrap();
+        if let EventData::ActivityJoin(e) = event {
+            assert_eq!(e.secret, "join_me");
+        } else {
+            panic!("Expected ActivityJoin event");
+        }
+    }
+
+    #[test]
+    fn parse_error_event() {
+        let response = IpcResponse {
+            cmd: Some("DISPATCH".to_string()),
+            data: Some(serde_json::json!({"code": 4000, "message": "Bad request"})),
+            evt: Some("ERROR".to_string()),
+            nonce: None,
+        };
+
+        let event = response.parse_event().unwrap().unwrap();
+        if let EventData::Error(e) = event {
+            assert_eq!(e.code, 4000);
+            assert_eq!(e.message, "Bad request");
+        } else {
+            panic!("Expected Error event");
+        }
     }
 }

--- a/src/ipc/protocol.rs
+++ b/src/ipc/protocol.rs
@@ -1,4 +1,6 @@
-use crate::error::{DiscordIpcError, ProtocolContext};
+use crate::error::{
+    DiscordIpcError, InvalidResponseKind, ProtocolContext, ProtocolViolationKind,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -69,6 +71,7 @@ impl TryFrom<u32> for Opcode {
                     payload_size: None,
                 };
                 Err(DiscordIpcError::protocol_violation(
+                    ProtocolViolationKind::InvalidOpcodeValue,
                     format!("Invalid opcode value: {}", value),
                     context,
                 ))
@@ -126,7 +129,8 @@ impl IpcResponse {
         match event_name {
             "READY" => {
                 let data = self.data.clone().ok_or_else(|| {
-                    DiscordIpcError::InvalidResponse(
+                    DiscordIpcError::invalid_response(
+                        InvalidResponseKind::MissingEventData,
                         "READY event is missing the data payload".to_string(),
                     )
                 })?;

--- a/src/ipc/protocol.rs
+++ b/src/ipc/protocol.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2025-2026 Sreehari Anil and project contributors
+
 use crate::error::{DiscordIpcError, InvalidResponseKind, ProtocolContext, ProtocolViolationKind};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/src/ipc/protocol.rs
+++ b/src/ipc/protocol.rs
@@ -2,6 +2,32 @@ use crate::error::{DiscordIpcError, ProtocolContext};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+/// Partial user object from Discord READY event payload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PartialUser {
+    pub id: Option<String>,
+    pub username: Option<String>,
+    pub discriminator: Option<String>,
+    pub avatar: Option<String>,
+    pub bot: Option<bool>,
+}
+
+/// READY event payload returned by Discord IPC after handshake.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReadyEvent {
+    pub user: Option<PartialUser>,
+}
+
+/// Parsed Discord IPC events.
+#[derive(Debug, Clone)]
+pub enum EventData {
+    Ready(ReadyEvent),
+    Unknown {
+        name: String,
+        data: Option<Value>,
+    },
+}
+
 /// Discord IPC Opcodes
 #[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -88,6 +114,32 @@ pub struct IpcResponse {
     pub data: Option<Value>,
     pub evt: Option<String>,
     pub nonce: Option<String>,
+}
+
+impl IpcResponse {
+    /// Parse this response into a typed event payload when `evt` is present.
+    pub fn parse_event(&self) -> Result<Option<EventData>, DiscordIpcError> {
+        let Some(event_name) = self.evt.as_deref() else {
+            return Ok(None);
+        };
+
+        match event_name {
+            "READY" => {
+                let data = self.data.clone().ok_or_else(|| {
+                    DiscordIpcError::InvalidResponse(
+                        "READY event is missing the data payload".to_string(),
+                    )
+                })?;
+                let ready = serde_json::from_value::<ReadyEvent>(data)
+                    .map_err(DiscordIpcError::DeserializationFailed)?;
+                Ok(Some(EventData::Ready(ready)))
+            }
+            other => Ok(Some(EventData::Unknown {
+                name: other.to_string(),
+                data: self.data.clone(),
+            })),
+        }
+    }
 }
 
 /// Constants and configuration for Discord IPC protocol

--- a/src/ipc/protocol.rs
+++ b/src/ipc/protocol.rs
@@ -1,6 +1,4 @@
-use crate::error::{
-    DiscordIpcError, InvalidResponseKind, ProtocolContext, ProtocolViolationKind,
-};
+use crate::error::{DiscordIpcError, InvalidResponseKind, ProtocolContext, ProtocolViolationKind};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -24,10 +22,7 @@ pub struct ReadyEvent {
 #[derive(Debug, Clone)]
 pub enum EventData {
     Ready(ReadyEvent),
-    Unknown {
-        name: String,
-        data: Option<Value>,
-    },
+    Unknown { name: String, data: Option<Value> },
 }
 
 /// Discord IPC Opcodes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,10 @@ pub use activity::ActivitySecrets;
 pub use activity::{
     Activity, ActivityAssets, ActivityBuilder, ActivityButton, ActivityParty, ActivityTimestamps,
 };
-pub use error::{DiscordIpcError, ProtocolContext, Result};
+pub use error::{
+    DiscordIpcError, HandshakeFailureKind, InvalidActivityKind, InvalidResponseKind,
+    ProtocolContext, ProtocolViolationKind, Result,
+};
 pub use ipc::protocol::IpcConfig;
 pub use ipc::{
     Command, DiscoveredPipe, EventData, IpcConnection, Opcode, PartialUser, PipeConfig,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! presenceforge = { version = "0.1.0", features = ["tokio-runtime"] }
+//! presenceforge = { version = "0.2.0", features = ["tokio-runtime"] }
 //! tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 //! ```
 //!
@@ -90,7 +90,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! presenceforge = { version = "0.1.0", features = ["async-std-runtime"] }
+//! presenceforge = { version = "0.2.0", features = ["async-std-runtime"] }
 //! async-std = { version = "1", features = ["attributes"] }
 //! ```
 //!
@@ -125,7 +125,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! presenceforge = { version = "0.1.0", features = ["smol-runtime"] }
+//! presenceforge = { version = "0.2.0", features = ["smol-runtime"] }
 //! smol = "2"
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,10 @@ pub use activity::{
 };
 pub use error::{DiscordIpcError, ProtocolContext, Result};
 pub use ipc::protocol::IpcConfig;
-pub use ipc::{Command, DiscoveredPipe, IpcConnection, Opcode, PipeConfig};
+pub use ipc::{
+    Command, DiscoveredPipe, EventData, IpcConnection, Opcode, PartialUser, PipeConfig,
+    ReadyEvent,
+};
 pub use macros::is_debug_enabled;
 
 // Re-export the synchronous API for backwards compatibility

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,8 +186,8 @@ pub use activity::{
     ActivityValidationError,
 };
 pub use error::{
-    DiscordIpcError, HandshakeFailureKind, InvalidActivityKind, InvalidResponseKind,
-    ProtocolContext, ProtocolViolationKind, Result,
+    DiscordIpcError, HandshakeFailureKind, InvalidResponseKind, ProtocolContext,
+    ProtocolViolationKind, Result,
 };
 pub use ipc::protocol::IpcConfig;
 pub use ipc::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,6 +183,7 @@ pub mod retry;
 pub use activity::ActivitySecrets;
 pub use activity::{
     Activity, ActivityAssets, ActivityBuilder, ActivityButton, ActivityParty, ActivityTimestamps,
+    ActivityValidationError,
 };
 pub use error::{
     DiscordIpcError, HandshakeFailureKind, InvalidActivityKind, InvalidResponseKind,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,8 +191,7 @@ pub use error::{
 };
 pub use ipc::protocol::IpcConfig;
 pub use ipc::{
-    Command, DiscoveredPipe, EventData, IpcConnection, Opcode, PartialUser, PipeConfig,
-    ReadyEvent,
+    Command, DiscoveredPipe, EventData, IpcConnection, Opcode, PartialUser, PipeConfig, ReadyEvent,
 };
 pub use macros::is_debug_enabled;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -11,12 +11,13 @@ pub fn is_debug_enabled() -> bool {
             .unwrap_or(false)
     })
 }
-/// Macro for conditional debug printing
+
+/// Macro for conditional debug printing using the log crate
 #[macro_export]
 macro_rules! debug_println {
     ($($arg:tt)*) => {
         if $crate::macros::is_debug_enabled() {
-            println!($($arg)*);
+            log::debug!($($arg)*);
         }
     };
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // Copyright (c) 2025-2026 Sreehari Anil and project contributors
 
-/// Global debug flag to control debug output
-/// Set to `true` to enable debug prints or use PRESENCEFORGE_DEBUG=1 environment variable
+/// Global debug flag to control internal library debug output.
+///
+/// To see internal logs:
+/// 1. Set `PRESENCEFORGE_DEBUG=1` environment variable.
+/// 2. Set `RUST_LOG=debug` (or higher) environment variable.
+/// 3. Initialize a logger (like `env_logger`) in your application.
 use std::sync::OnceLock;
 
 static DEBUG_ENABLED: OnceLock<bool> = OnceLock::new();
@@ -15,7 +19,10 @@ pub fn is_debug_enabled() -> bool {
     })
 }
 
-/// Macro for conditional debug printing using the log crate
+/// Macro for conditional debug printing using the log crate.
+///
+/// Only emits logs if `PRESENCEFORGE_DEBUG` is set.
+/// Requires an active logger (e.g., `RUST_LOG=debug`) to be visible.
 #[macro_export]
 macro_rules! debug_println {
     ($($arg:tt)*) => {

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -453,7 +453,10 @@ fn test_retry_stops_on_non_recoverable_error() {
     let result: std::result::Result<(), DiscordIpcError> = with_retry(&config, || {
         attempt_count += 1;
         // InvalidActivity is not recoverable
-        Err(DiscordIpcError::InvalidActivity("test".to_string()))
+        Err(DiscordIpcError::invalid_activity(
+            crate::error::InvalidActivityKind::ValidationFailed,
+            "test",
+        ))
     });
 
     assert!(result.is_err());

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -453,9 +453,8 @@ fn test_retry_stops_on_non_recoverable_error() {
     let result: std::result::Result<(), DiscordIpcError> = with_retry(&config, || {
         attempt_count += 1;
         // InvalidActivity is not recoverable
-        Err(DiscordIpcError::invalid_activity(
-            crate::error::InvalidActivityKind::ValidationFailed,
-            "test",
+        Err(DiscordIpcError::InvalidActivity(
+            crate::activity::ActivityValidationError::ButtonUrlMissingScheme,
         ))
     });
 

--- a/src/sync/client.rs
+++ b/src/sync/client.rs
@@ -199,7 +199,7 @@ impl DiscordIpcClient {
 
         match response.parse_event()? {
             Some(EventData::Ready(ready)) => Ok(Some(ready)),
-            Some(EventData::Unknown { .. }) | None => Ok(None),
+            _ => Ok(None),
         }
     }
 
@@ -226,6 +226,7 @@ impl DiscordIpcClient {
                 "activity": activity
             }),
             nonce: nonce.clone(),
+            evt: None,
         };
 
         let payload = serde_json::to_value(message)?;
@@ -293,6 +294,7 @@ impl DiscordIpcClient {
                 "activity": Value::Null
             }),
             nonce: nonce.clone(),
+            evt: None,
         };
 
         let payload = serde_json::to_value(message)?;
@@ -335,6 +337,96 @@ impl DiscordIpcClient {
         }
 
         Ok(response)
+    }
+
+    /// Subscribe to a Discord IPC event
+    pub fn subscribe<S: Into<String>>(&mut self, event: S, args: Value) -> Result {
+        let event = event.into();
+        let nonce = generate_nonce("subscribe");
+
+        let message = IpcMessage {
+            cmd: Command::Subscribe,
+            args,
+            nonce: nonce.clone(),
+            evt: Some(event),
+        };
+
+        let payload = serde_json::to_value(message)?;
+        self.connection.send(Opcode::Frame, &payload)?;
+
+        let (_, response) = self.recv_for_nonce(&nonce)?;
+
+        if let Some(err) = response.get("error") {
+            let code = err.get("code").and_then(|c| c.as_i64()).unwrap_or(0) as i32;
+            let message = err
+                .get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("Unknown error");
+            return Err(DiscordIpcError::discord_error(code, message));
+        }
+
+        Ok(())
+    }
+
+    /// Unsubscribe from a Discord IPC event
+    pub fn unsubscribe<S: Into<String>>(&mut self, event: S, args: Value) -> Result {
+        let event = event.into();
+        let nonce = generate_nonce("unsubscribe");
+
+        let message = IpcMessage {
+            cmd: Command::Unsubscribe,
+            args,
+            nonce: nonce.clone(),
+            evt: Some(event),
+        };
+
+        let payload = serde_json::to_value(message)?;
+        self.connection.send(Opcode::Frame, &payload)?;
+
+        let (_, response) = self.recv_for_nonce(&nonce)?;
+
+        if let Some(err) = response.get("error") {
+            let code = err.get("code").and_then(|c| c.as_i64()).unwrap_or(0) as i32;
+            let message = err
+                .get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("Unknown error");
+            return Err(DiscordIpcError::discord_error(code, message));
+        }
+
+        Ok(())
+    }
+
+    /// Blocks until the next event is received
+    pub fn next_event(&mut self) -> Result<EventData> {
+        if let Some(event) = self.take_pending_event()? {
+            return Ok(event);
+        }
+
+        loop {
+            let (opcode, payload) = self.connection.recv()?;
+
+            if !opcode.is_frame_response() {
+                self.pending_messages
+                    .push_back(PendingMessage::new(opcode, payload));
+                continue;
+            }
+
+            let response: IpcResponse = serde_json::from_value(payload.clone())
+                .map_err(DiscordIpcError::DeserializationFailed)?;
+
+            if let Some(event) = response.parse_event()? {
+                return Ok(event);
+            }
+
+            self.pending_messages
+                .push_back(PendingMessage::new(opcode, payload));
+        }
+    }
+
+    /// Checks for a queued event without blocking
+    pub fn poll_event(&mut self) -> Result<Option<EventData>> {
+        self.take_pending_event()
     }
 
     /// Send a raw IPC message
@@ -475,6 +567,30 @@ impl DiscordIpcClient {
             .and_then(|n| n.as_str())
             .map(|actual| actual == expected_nonce)
             .unwrap_or(false)
+    }
+
+    fn take_pending_event(&mut self) -> Result<Option<EventData>> {
+        let position = self
+            .pending_messages
+            .iter()
+            .position(|message| Self::value_is_event(&message.payload));
+
+        if let Some(index) = position {
+            if let Some(message) = self.pending_messages.remove(index) {
+                let response: IpcResponse = serde_json::from_value(message.payload)
+                    .map_err(DiscordIpcError::DeserializationFailed)?;
+                return response.parse_event();
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn value_is_event(value: &Value) -> bool {
+        value
+            .get("evt")
+            .and_then(|evt| evt.as_str())
+            .is_some()
     }
 }
 

--- a/src/sync/client.rs
+++ b/src/sync/client.rs
@@ -7,9 +7,7 @@ use std::time::{Duration, Instant};
 
 use crate::activity::Activity;
 use crate::debug_println;
-use crate::error::{
-    DiscordIpcError, HandshakeFailureKind, InvalidActivityKind, InvalidResponseKind, Result,
-};
+use crate::error::{DiscordIpcError, HandshakeFailureKind, InvalidResponseKind, Result};
 use crate::ipc::{
     constants, Command, EventData, HandshakePayload, IpcConnection, IpcMessage, IpcResponse,
     Opcode, PipeConfig, ReadyEvent,
@@ -216,12 +214,7 @@ impl DiscordIpcClient {
     /// Returns a `DiscordIpcError` if serialization fails or if Discord returns an error
     pub fn set_activity(&mut self, activity: &Activity) -> Result {
         // Validate the activity first
-        if let Err(reason) = activity.validate() {
-            return Err(DiscordIpcError::invalid_activity(
-                InvalidActivityKind::ValidationFailed,
-                reason.to_string(),
-            ));
-        }
+        activity.validate()?;
 
         // Generate a cryptographically secure unique nonce for this request
         let nonce = generate_nonce("set-activity");

--- a/src/sync/client.rs
+++ b/src/sync/client.rs
@@ -20,6 +20,7 @@ pub struct DiscordIpcClient {
     pipe_config: Option<PipeConfig>,
     timeout_ms: Option<u64>,
     pending_messages: VecDeque<PendingMessage>,
+    connected: bool,
 }
 
 impl DiscordIpcClient {
@@ -67,6 +68,7 @@ impl DiscordIpcClient {
             pipe_config: config,
             timeout_ms: None,
             pending_messages: VecDeque::new(),
+            connected: false,
         })
     }
 
@@ -126,6 +128,7 @@ impl DiscordIpcClient {
             pipe_config: config,
             timeout_ms: Some(timeout_ms),
             pending_messages: VecDeque::new(),
+            connected: false,
         })
     }
 
@@ -140,6 +143,7 @@ impl DiscordIpcClient {
     /// Returns a `DiscordIpcError::HandshakeFailed` if the handshake fails
     pub fn connect(&mut self) -> Result<Value> {
         self.pending_messages.clear();
+        self.connected = false;
 
         let handshake = HandshakePayload {
             v: constants::IPC_VERSION,
@@ -177,6 +181,7 @@ impl DiscordIpcClient {
             )));
         }
 
+        self.connected = true;
         Ok(response)
     }
 
@@ -326,6 +331,11 @@ impl DiscordIpcClient {
         self.next_message()
     }
 
+    /// Returns `true` once a handshake has been successfully completed.
+    pub fn is_connected(&self) -> bool {
+        self.connected
+    }
+
     /// Remove pending responses older than the provided `max_age` and return how many were dropped.
     pub fn cleanup_pending(&mut self, max_age: Duration) -> usize {
         if max_age.is_zero() {
@@ -345,6 +355,7 @@ impl DiscordIpcClient {
     pub fn close(&mut self) {
         self.connection.close();
         self.pending_messages.clear();
+        self.connected = false;
     }
 
     /// Reconnect to Discord IPC
@@ -393,6 +404,7 @@ impl DiscordIpcClient {
             IpcConnection::new_with_config(self.pipe_config.clone())?
         };
         self.pending_messages.clear();
+        self.connected = false;
 
         // Perform handshake
         self.connect()

--- a/src/sync/client.rs
+++ b/src/sync/client.rs
@@ -587,10 +587,7 @@ impl DiscordIpcClient {
     }
 
     fn value_is_event(value: &Value) -> bool {
-        value
-            .get("evt")
-            .and_then(|evt| evt.as_str())
-            .is_some()
+        value.get("evt").and_then(|evt| evt.as_str()).is_some()
     }
 }
 

--- a/src/sync/client.rs
+++ b/src/sync/client.rs
@@ -219,7 +219,7 @@ impl DiscordIpcClient {
         if let Err(reason) = activity.validate() {
             return Err(DiscordIpcError::invalid_activity(
                 InvalidActivityKind::ValidationFailed,
-                reason,
+                reason.to_string(),
             ));
         }
 

--- a/src/sync/client.rs
+++ b/src/sync/client.rs
@@ -9,7 +9,8 @@ use crate::activity::Activity;
 use crate::debug_println;
 use crate::error::{DiscordIpcError, Result};
 use crate::ipc::{
-    constants, Command, HandshakePayload, IpcConnection, IpcMessage, Opcode, PipeConfig,
+    constants, Command, EventData, HandshakePayload, IpcConnection, IpcMessage, IpcResponse,
+    Opcode, PipeConfig, ReadyEvent,
 };
 use crate::nonce::generate_nonce;
 
@@ -183,6 +184,23 @@ impl DiscordIpcClient {
 
         self.connected = true;
         Ok(response)
+    }
+
+    /// Perform handshake and return the typed READY payload when available.
+    pub fn connect_with_ready(&mut self) -> Result<Option<ReadyEvent>> {
+        let response = self.connect()?;
+        Self::ready_event_from_payload(&response)
+    }
+
+    /// Parse a raw IPC payload into a READY event if this payload is a READY dispatch.
+    pub fn ready_event_from_payload(payload: &Value) -> Result<Option<ReadyEvent>> {
+        let response: IpcResponse = serde_json::from_value(payload.clone())
+            .map_err(DiscordIpcError::DeserializationFailed)?;
+
+        match response.parse_event()? {
+            Some(EventData::Ready(ready)) => Ok(Some(ready)),
+            Some(EventData::Unknown { .. }) | None => Ok(None),
+        }
     }
 
     /// Set Discord Rich Presence activity

--- a/src/sync/client.rs
+++ b/src/sync/client.rs
@@ -7,7 +7,9 @@ use std::time::{Duration, Instant};
 
 use crate::activity::Activity;
 use crate::debug_println;
-use crate::error::{DiscordIpcError, Result};
+use crate::error::{
+    DiscordIpcError, HandshakeFailureKind, InvalidActivityKind, InvalidResponseKind, Result,
+};
 use crate::ipc::{
     constants, Command, EventData, HandshakePayload, IpcConnection, IpcMessage, IpcResponse,
     Opcode, PipeConfig, ReadyEvent,
@@ -167,19 +169,19 @@ impl DiscordIpcClient {
             ) {
                 return Err(DiscordIpcError::discord_error(code as i32, message));
             } else {
-                return Err(DiscordIpcError::HandshakeFailed(format!(
-                    "Invalid error format: {}",
-                    err
-                )));
+                return Err(DiscordIpcError::handshake_failed(
+                    HandshakeFailureKind::InvalidErrorPayload,
+                    format!("Invalid error format: {}", err),
+                ));
             }
         }
 
         // Verify opcode is correct for handshake response
         if !opcode.is_handshake_response() {
-            return Err(DiscordIpcError::HandshakeFailed(format!(
-                "Expected handshake response opcode, got {:?}",
-                opcode
-            )));
+            return Err(DiscordIpcError::handshake_failed(
+                HandshakeFailureKind::UnexpectedOpcode,
+                format!("Expected handshake response opcode, got {:?}", opcode),
+            ));
         }
 
         self.connected = true;
@@ -215,7 +217,10 @@ impl DiscordIpcClient {
     pub fn set_activity(&mut self, activity: &Activity) -> Result {
         // Validate the activity first
         if let Err(reason) = activity.validate() {
-            return Err(DiscordIpcError::InvalidActivity(reason));
+            return Err(DiscordIpcError::invalid_activity(
+                InvalidActivityKind::ValidationFailed,
+                reason,
+            ));
         }
 
         // Generate a cryptographically secure unique nonce for this request
@@ -241,10 +246,10 @@ impl DiscordIpcClient {
 
         // Check if we got the correct response type
         if !opcode.is_frame_response() {
-            return Err(DiscordIpcError::InvalidResponse(format!(
-                "Expected frame response, got {:?}",
-                opcode
-            )));
+            return Err(DiscordIpcError::invalid_response(
+                InvalidResponseKind::UnexpectedOpcode,
+                format!("Expected frame response, got {:?}", opcode),
+            ));
         }
 
         // Check for error in the response
@@ -255,20 +260,20 @@ impl DiscordIpcClient {
             ) {
                 return Err(DiscordIpcError::discord_error(code as i32, message));
             } else {
-                return Err(DiscordIpcError::InvalidResponse(format!(
-                    "Invalid error format in response: {}",
-                    err
-                )));
+                return Err(DiscordIpcError::invalid_response(
+                    InvalidResponseKind::InvalidErrorPayload,
+                    format!("Invalid error format in response: {}", err),
+                ));
             }
         }
 
         // Verify nonce matches to ensure we got the right response
         if let Some(resp_nonce) = response.get("nonce").and_then(|n| n.as_str()) {
             if resp_nonce != nonce {
-                return Err(DiscordIpcError::InvalidResponse(format!(
-                    "Nonce mismatch: expected {}, got {}",
-                    nonce, resp_nonce
-                )));
+                return Err(DiscordIpcError::invalid_response(
+                    InvalidResponseKind::NonceMismatch,
+                    format!("Nonce mismatch: expected {}, got {}", nonce, resp_nonce),
+                ));
             }
         }
 
@@ -305,10 +310,10 @@ impl DiscordIpcClient {
 
         // Check if we got the correct response type
         if !opcode.is_frame_response() {
-            return Err(DiscordIpcError::InvalidResponse(format!(
-                "Expected frame response, got {:?}",
-                opcode
-            )));
+            return Err(DiscordIpcError::invalid_response(
+                InvalidResponseKind::UnexpectedOpcode,
+                format!("Expected frame response, got {:?}", opcode),
+            ));
         }
 
         // Check for error in the response
@@ -319,20 +324,20 @@ impl DiscordIpcClient {
             ) {
                 return Err(DiscordIpcError::discord_error(code as i32, message));
             } else {
-                return Err(DiscordIpcError::InvalidResponse(format!(
-                    "Invalid error format in response: {}",
-                    err
-                )));
+                return Err(DiscordIpcError::invalid_response(
+                    InvalidResponseKind::InvalidErrorPayload,
+                    format!("Invalid error format in response: {}", err),
+                ));
             }
         }
 
         // Verify nonce matches to ensure we got the right response
         if let Some(resp_nonce) = response.get("nonce").and_then(|n| n.as_str()) {
             if resp_nonce != nonce {
-                return Err(DiscordIpcError::InvalidResponse(format!(
-                    "Nonce mismatch: expected {}, got {}",
-                    nonce, resp_nonce
-                )));
+                return Err(DiscordIpcError::invalid_response(
+                    InvalidResponseKind::NonceMismatch,
+                    format!("Nonce mismatch: expected {}, got {}", nonce, resp_nonce),
+                ));
             }
         }
 

--- a/tests/integration_error_handling.rs
+++ b/tests/integration_error_handling.rs
@@ -18,6 +18,21 @@ fn error_category_matches_constructor() {
 }
 
 #[test]
+fn invalid_activity_wraps_validation_error() {
+    use presenceforge::ActivityValidationError;
+    let val_error = ActivityValidationError::StateTooLong {
+        max: 128,
+        actual: 129,
+    };
+    let error = DiscordIpcError::from(val_error.clone());
+
+    match error {
+        DiscordIpcError::InvalidActivity(e) => assert_eq!(e, val_error),
+        _ => panic!("Expected InvalidActivity variant"),
+    }
+}
+
+#[test]
 fn protocol_violation_context_is_preserved() {
     let context = ProtocolContext::with_opcodes(Opcode::Handshake.into(), Opcode::Frame.into());
     let error = DiscordIpcError::protocol_violation(

--- a/tests/integration_error_handling.rs
+++ b/tests/integration_error_handling.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2025-2026 Sreehari Anil and project contributors
+
 use presenceforge::error::{ErrorCategory, InvalidResponseKind};
 use presenceforge::{DiscordIpcError, Opcode, ProtocolContext};
 

--- a/tests/integration_error_handling.rs
+++ b/tests/integration_error_handling.rs
@@ -1,4 +1,4 @@
-use presenceforge::error::ErrorCategory;
+use presenceforge::error::{ErrorCategory, InvalidResponseKind};
 use presenceforge::{DiscordIpcError, Opcode, ProtocolContext};
 
 #[test]
@@ -7,7 +7,8 @@ fn error_category_matches_constructor() {
     assert!(error.is_connection_error());
     assert_eq!(error.category(), ErrorCategory::Connection);
 
-    let protocol_error = DiscordIpcError::InvalidResponse("bad".into());
+    let protocol_error =
+        DiscordIpcError::invalid_response(InvalidResponseKind::UnexpectedOpcode, "bad");
     assert_eq!(protocol_error.category(), ErrorCategory::Protocol);
     assert!(protocol_error.is_recoverable());
 
@@ -19,7 +20,11 @@ fn error_category_matches_constructor() {
 #[test]
 fn protocol_violation_context_is_preserved() {
     let context = ProtocolContext::with_opcodes(Opcode::Handshake.into(), Opcode::Frame.into());
-    let error = DiscordIpcError::protocol_violation("unexpected opcode", context.clone());
+    let error = DiscordIpcError::protocol_violation(
+        presenceforge::error::ProtocolViolationKind::Other,
+        "unexpected opcode",
+        context.clone(),
+    );
 
     match error {
         DiscordIpcError::ProtocolViolation {

--- a/tests/integration_ipc_protocol.rs
+++ b/tests/integration_ipc_protocol.rs
@@ -68,5 +68,8 @@ fn ready_event_is_parsed_from_payload() {
         .expect("payload should deserialize")
         .expect("ready event should be present");
 
-    assert_eq!(ready.user.and_then(|u| u.username), Some("tester".to_string()));
+    assert_eq!(
+        ready.user.and_then(|u| u.username),
+        Some("tester".to_string())
+    );
 }

--- a/tests/integration_ipc_protocol.rs
+++ b/tests/integration_ipc_protocol.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2025-2026 Sreehari Anil and project contributors
+
 use presenceforge::{Command, DiscordIpcClient, DiscordIpcError, IpcConfig, Opcode};
 use serde_json::json;
 use std::convert::TryFrom;

--- a/tests/integration_ipc_protocol.rs
+++ b/tests/integration_ipc_protocol.rs
@@ -1,4 +1,4 @@
-use presenceforge::{Command, DiscordIpcError, IpcConfig, Opcode};
+use presenceforge::{Command, DiscordIpcClient, DiscordIpcError, IpcConfig, Opcode};
 use serde_json::json;
 use std::convert::TryFrom;
 
@@ -49,4 +49,24 @@ fn command_serializes_to_expected_strings() {
 
     let serialized = serde_json::to_string(&message).expect("serialize embed message");
     assert!(serialized.contains("\"SUBSCRIBE\""));
+}
+
+#[test]
+fn ready_event_is_parsed_from_payload() {
+    let payload = json!({
+        "cmd": "DISPATCH",
+        "evt": "READY",
+        "data": {
+            "user": {
+                "id": "1234",
+                "username": "tester"
+            }
+        }
+    });
+
+    let ready = DiscordIpcClient::ready_event_from_payload(&payload)
+        .expect("payload should deserialize")
+        .expect("ready event should be present");
+
+    assert_eq!(ready.user.and_then(|u| u.username), Some("tester".to_string()));
 }

--- a/tests/integration_retry.rs
+++ b/tests/integration_retry.rs
@@ -1,4 +1,5 @@
 use presenceforge::retry::with_retry;
+use presenceforge::error::InvalidActivityKind;
 use presenceforge::{retry::RetryConfig, DiscordIpcError};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -29,7 +30,10 @@ fn retry_stops_on_non_recoverable_error() {
     let attempts = Arc::new(AtomicUsize::new(0));
     let result: presenceforge::Result<&str> = with_retry(&quick_retry_config(5), || {
         attempts.fetch_add(1, Ordering::SeqCst);
-        Err(DiscordIpcError::InvalidActivity("bad".into()))
+        Err(DiscordIpcError::invalid_activity(
+            InvalidActivityKind::ValidationFailed,
+            "bad",
+        ))
     });
 
     assert!(result.is_err());

--- a/tests/integration_retry.rs
+++ b/tests/integration_retry.rs
@@ -1,6 +1,5 @@
-use presenceforge::error::InvalidActivityKind;
 use presenceforge::retry::with_retry;
-use presenceforge::{retry::RetryConfig, DiscordIpcError};
+use presenceforge::{retry::RetryConfig, ActivityValidationError, DiscordIpcError};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
@@ -30,9 +29,8 @@ fn retry_stops_on_non_recoverable_error() {
     let attempts = Arc::new(AtomicUsize::new(0));
     let result: presenceforge::Result<&str> = with_retry(&quick_retry_config(5), || {
         attempts.fetch_add(1, Ordering::SeqCst);
-        Err(DiscordIpcError::invalid_activity(
-            InvalidActivityKind::ValidationFailed,
-            "bad",
+        Err(DiscordIpcError::InvalidActivity(
+            ActivityValidationError::ButtonUrlMissingScheme,
         ))
     });
 

--- a/tests/integration_retry.rs
+++ b/tests/integration_retry.rs
@@ -1,5 +1,5 @@
-use presenceforge::retry::with_retry;
 use presenceforge::error::InvalidActivityKind;
+use presenceforge::retry::with_retry;
 use presenceforge::{retry::RetryConfig, DiscordIpcError};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;


### PR DESCRIPTION
This pull request releases PresenceForge v0.2.0, introducing major new features, API changes, and documentation updates. The most significant additions are a new IPC event system (allowing event subscription and polling), improvements to IPC discovery, enhancements to the activity builder, and a refactored error model with more granular types. The documentation and examples have been updated to reflect these changes.

**New IPC Event System:**
- Added event subscription API (`subscribe`, `unsubscribe`, `next_event`, `poll_event`) for both sync and async clients, with typed event models and new example code. [[1]](diffhunk://#diff-e358407f015610a25f8506b7364064801a064894514c4ea382e6ea18d5f5e5f9R1-R67) [[2]](diffhunk://#diff-aad5ecc11464df5ad697d70b7611a32437d06da77119dfe5a5665492490010a4R15) [[3]](diffhunk://#diff-aad5ecc11464df5ad697d70b7611a32437d06da77119dfe5a5665492490010a4R162-R209) [[4]](diffhunk://#diff-aad5ecc11464df5ad697d70b7611a32437d06da77119dfe5a5665492490010a4R98-R115) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R225-R231) [[6]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R84-R87)

**Error Model Refactor (Breaking):**
- Replaced string-based errors with typed error kinds (`HandshakeFailureKind`, `InvalidResponseKind`, etc.), updated `DiscordIpcError` variants, and improved error documentation. [[1]](diffhunk://#diff-e358407f015610a25f8506b7364064801a064894514c4ea382e6ea18d5f5e5f9R1-R67) [[2]](diffhunk://#diff-aad5ecc11464df5ad697d70b7611a32437d06da77119dfe5a5665492490010a4L523-R624) [[3]](diffhunk://#diff-aad5ecc11464df5ad697d70b7611a32437d06da77119dfe5a5665492490010a4L559-R670)

**Activity Builder Enhancements:**
- Added `.end_timestamp_from_now(Duration)` and `.party_simple()` methods for easier activity configuration, with updated documentation and examples. [[1]](diffhunk://#diff-e358407f015610a25f8506b7364064801a064894514c4ea382e6ea18d5f5e5f9R1-R67) [[2]](diffhunk://#diff-d17178cb70fd47dd790e2aa42d9a9d036b97a2290817e60a4dbe3121c5f16568R118-R128) [[3]](diffhunk://#diff-d17178cb70fd47dd790e2aa42d9a9d036b97a2290817e60a4dbe3121c5f16568R164-R172) [[4]](diffhunk://#diff-d17178cb70fd47dd790e2aa42d9a9d036b97a2290817e60a4dbe3121c5f16568R277-R280) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L239-R251)

**IPC Discovery Improvements:**
- Introduced a new IPC discovery module with broader coverage for Unix environments and shared helpers across runtimes.

**Documentation and Versioning Updates:**
- Updated all docs, examples, and badges to reference v0.2.0, documented new APIs, and improved usage guidance throughout. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R9) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R37-R52) [[3]](diffhunk://#diff-aad5ecc11464df5ad697d70b7611a32437d06da77119dfe5a5665492490010a4L5-R5) [[4]](diffhunk://#diff-64948138e63bf4394ceef8be9d52de9bc43ae95583dccd2178ef9713c005ebedL3-R3) [[5]](diffhunk://#diff-64948138e63bf4394ceef8be9d52de9bc43ae95583dccd2178ef9713c005ebedL66-R72) [[6]](diffhunk://#diff-d17178cb70fd47dd790e2aa42d9a9d036b97a2290817e60a4dbe3121c5f16568L177-R197)

Please refer to the new `changelogs/0.2.0.md` for a full breakdown of changes.

closes #11 