### PR TITLE
Release v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "presenceforge"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-std",
  "blocking",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presenceforge"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Sreehari Anil <sreehari7102008@gmail.com>"]
 description = "A library for Discord Rich Presence (IPC) integration"

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 A Rust library for Discord Rich Presence that actually works without the headaches. No more fighting with the Discord SDK or dealing with complex C bindings.
 
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://github.com/Sreehari425/presenceforge#license)
-[![Rust](https://img.shields.io/badge/rust-1.70+-blue.svg)](https://www.rust-lang.org)
+[![Rust](https://img.shields.io/badge/rust-1.78+-blue.svg)](https://www.rust-lang.org)
 ![Crates.io Version](https://img.shields.io/crates/v/presenceforge)
 
-> **Note**: This is currently in development (v0.2.0). Things might break.
+> **Note**: This is currently in development (v0.2.1). Things might break.
 > This is a learning/hobby project.
 > Features and APIs may change in future versions.
 
@@ -21,7 +21,7 @@ A Rust library for Discord Rich Presence that actually works without the headach
 
 **Want to build your own RPC client?**
 
-- [Discord RPC from Scratch](docs/DISCORD_RPC_FROM_SCRATCH.md) - this is What I found while building this library. I could be wrong about some things, so feel free to correct me!
+- [Discord RPC from Scratch](docs/DISCORD_RPC_FROM_SCRATCH.md) - Notes from building this library from scratch, including protocol details and implementation tradeoffs.
 
 ## What Works
 
@@ -42,18 +42,18 @@ Add PresenceForge to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-presenceforge = "0.2.0"
+presenceforge = "0.2.1"
 ```
 
 For async support, add one of the runtime features:
 
 ```toml
 [dependencies]
-presenceforge = { version = "0.2.0", features = ["tokio-runtime"] }
+presenceforge = { version = "0.2.1", features = ["tokio-runtime"] }
 # OR
-presenceforge = { version = "0.1.0", features = ["async-std-runtime"] }
+presenceforge = { version = "0.2.1", features = ["async-std-runtime"] }
 # OR
-presenceforge = { version = "0.1.0", features = ["smol-runtime"] }
+presenceforge = { version = "0.2.1", features = ["smol-runtime"] }
 ```
 
 ### Basic Usage (Synchronous)
@@ -70,7 +70,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let activity = ActivityBuilder::new()
         .state("Playing a game")
         .details("In the menu")
-        .start_timestamp_now()
+        .start_timestamp_now()?
         .large_image("game_logo")
         .large_text("My Awesome Game")
         .build();
@@ -99,7 +99,7 @@ async fn main() -> Result {
     let activity = ActivityBuilder::new()
         .state("Playing a game")
         .details("In the menu")
-        .start_timestamp_now()
+        .start_timestamp_now()?
         .large_image("game_logo")
         .large_text("My Awesome Game")
         .build();
@@ -128,7 +128,7 @@ async fn main() -> Result {
     let activity = ActivityBuilder::new()
         .state("Playing a game")
         .details("In the menu")
-        .start_timestamp_now()
+        .start_timestamp_now()?
         .large_image("game_logo")
         .large_text("My Awesome Game")
         .build();
@@ -151,12 +151,12 @@ fn main() -> Result {
     smol::block_on(async {
         let mut client = AsyncDiscordIpcClient::new("your_client_id").await?;
         client.connect().await?;
-    debug_assert!(client.is_connected(), "Discord handshake failed");
+        debug_assert!(client.is_connected(), "Discord handshake failed");
 
         let activity = ActivityBuilder::new()
             .state("Playing a game")
             .details("In the menu")
-            .start_timestamp_now()
+            .start_timestamp_now()?
             .large_image("game_logo")
             .large_text("My Awesome Game")
             .build();
@@ -238,7 +238,7 @@ The `ActivityBuilder` provides a fluent interface for creating activities:
 ActivityBuilder::new()
     .state("Custom state")           // What the player is doing
     .details("Custom details")       // Additional context
-    .start_timestamp_now()           // Start time (current)
+    .start_timestamp_now()?          // Start time (current)
     .start_timestamp(timestamp)      // Start time (custom)
     .end_timestamp(timestamp)        // End time
     .large_image("image_key")        // Large image asset
@@ -248,7 +248,7 @@ ActivityBuilder::new()
     .button("Label", "https://url")  // Clickable button (max 2)
     .party("id", 1, 4)               // Party size with custom ID
     .party_simple(1, 4)              // Party size with auto-generated ID
-    .end_timestamp_from_now(dur)     // End time relative to now
+    .end_timestamp_from_now(dur)?    // End time relative to now
     .build()
 ```
 
@@ -286,11 +286,26 @@ cargo run --example async_smol --features smol-runtime -- --client-id YOUR_CLIEN
 # Complete builder reference - Shows ALL ActivityBuilder options
 cargo run --example builder_all -- --client-id YOUR_CLIENT_ID
 
+# Flatpak-specific pipe selection
+cargo run --example basic_flatpak -- --client-id YOUR_CLIENT_ID
+
 # Connection retry and error handling
 cargo run --example connection_retry -- --client-id YOUR_CLIENT_ID
 
+# Async retry/reconnect with Tokio
+cargo run --example async_tokio_reconnect --features tokio-runtime -- --client-id YOUR_CLIENT_ID
+
+# Update activity without resetting the timer
+cargo run --example update_activity_tokio --features tokio-runtime -- --client-id YOUR_CLIENT_ID
+
 # Pipe selection and discovery
 cargo run --example pipe_selection -- --client-id YOUR_CLIENT_ID
+
+# IPC event subscription and polling
+cargo run --example event_listener -- --client-id YOUR_CLIENT_ID
+
+# Fetch typed READY payload data
+cargo run --example ready_event -- --client-id YOUR_CLIENT_ID
 ```
 
 Or use the .env file method (recommended for development):
@@ -317,8 +332,11 @@ use presenceforge::DiscordIpcError;
 use presenceforge::sync::DiscordIpcClient;
 match client.connect() {
     Ok(_) => println!("Connected successfully!"),
-    Err(DiscordIpcError::ConnectionFailed) => {
+    Err(DiscordIpcError::ConnectionFailed(_)) => {
         eprintln!("Failed to connect - is Discord running?");
+    }
+    Err(DiscordIpcError::NoValidSocket) => {
+        eprintln!("No Discord IPC socket found - is Discord running?");
     }
     Err(e) => eprintln!("Error: {}", e),
 }

--- a/changelogs/0.2.1.md
+++ b/changelogs/0.2.1.md
@@ -1,0 +1,12 @@
+## [0.2.1] - release
+
+### Fixed
+
+#### READY Event User Parsing
+
+- Normalize empty string values in `PartialUser` string fields to `None` during deserialization.
+- Prevent `username: ""` from being exposed as `Some("")` in typed READY event payloads.
+
+### Testing
+
+- Added integration coverage for READY payloads where `user.username` is an empty string.

--- a/changelogs/0.2.1.md
+++ b/changelogs/0.2.1.md
@@ -7,6 +7,22 @@
 - Normalize empty string values in `PartialUser` string fields to `None` during deserialization.
 - Prevent `username: ""` from being exposed as `Some("")` in typed READY event payloads.
 
+#### Handshake Validation
+
+- Require a valid `DISPATCH` + `READY` handshake response before marking clients as connected.
+- Reject malformed or unexpected handshake frames more defensively in both sync and async clients.
+
+#### IPC Configuration
+
+- Apply `IpcConfig` to live client and transport behavior instead of leaving it as effectively dead configuration.
+- Use configured values for handshake IPC version, payload size limits, socket scan count, and retry interval.
+
+### Documentation
+
+- Refresh README, guides, and crate docs to match the current API and examples.
+- Correct stale async/runtime examples and reconnect/error-handling snippets.
+
 ### Testing
 
 - Added integration coverage for READY payloads where `user.username` is an empty string.
+- Added protocol tests for stricter handshake validation.

--- a/docs/ACTIVITY_BUILDER_REFERENCE.md
+++ b/docs/ACTIVITY_BUILDER_REFERENCE.md
@@ -194,7 +194,7 @@ let end_time = now + 300;
 ### 8. **Secrets** (For "Ask to Join" and Spectate features)
 
 > **⚠️ Feature Flag Required:** These methods require the `secrets` feature flag to be enabled.
-> Add to your `Cargo.toml`: `presenceforge = { version = "0.2.0", features = ["secrets"] }`
+> Add to your `Cargo.toml`: `presenceforge = { version = "0.2.1", features = ["secrets"] }`
 
 #### Note: untested feature
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -2,7 +2,7 @@
 
 API reference for PresenceForge (work-in-progress; APIs may change).
 
-> **Note:** PresenceForge v0.2.0 is an early development release.  
+> **Note:** PresenceForge v0.2.1 is an early development release.  
 > It’s functional, but features may change or be incomplete.
 
 ## Table of Contents
@@ -11,6 +11,7 @@ API reference for PresenceForge (work-in-progress; APIs may change).
 - [ActivityBuilder](#activitybuilder)
 - [Activity](#activity)
 - [PipeConfig](#pipeconfig)
+- [IpcConfig](#ipcconfig)
 - [IpcConnection](#ipcconnection)
 - [Event Subscription](#event-subscription)
 - [Error Types](#error-types)
@@ -73,6 +74,21 @@ let client = DiscordIpcClient::new_with_config(
 
 ---
 
+#### `DiscordIpcClient::new_with_ipc_config(client_id: impl Into<String>, ipc_config: IpcConfig) -> Result<Self>`
+
+Creates a new Discord IPC client with custom protocol configuration while still using automatic pipe discovery.
+
+```rust
+use presenceforge::{IpcConfig, sync::DiscordIpcClient};
+
+let client = DiscordIpcClient::new_with_ipc_config(
+    "client_id",
+    IpcConfig::fast_connect(),
+)?;
+```
+
+---
+
 ### Connection Methods
 
 #### `connect(&mut self) -> Result<serde_json::Value>`
@@ -95,6 +111,22 @@ let _handshake = client.connect()?; // JSON handshake payload
 
 ---
 
+#### `connect_with_ready(&mut self) -> Result<Option<ReadyEvent>>`
+
+Performs the handshake and returns the typed READY payload when Discord includes one.
+
+```rust
+let mut client = DiscordIpcClient::new("client_id")?;
+let ready = client.connect_with_ready()?;
+if let Some(ready) = ready {
+    if let Some(user) = ready.user {
+        println!("Connected as {:?}", user.username);
+    }
+}
+```
+
+---
+
 #### `is_connected(&self) -> bool`
 
 Returns `true` after a successful handshake and `false` otherwise.
@@ -113,8 +145,13 @@ if !client.is_connected() {
 
 ---
 
-// (No sync reconnect method)
-// If the connection is lost, recreate the client and call connect() again.
+#### `reconnect(&mut self) -> Result<serde_json::Value>`
+
+Re-establishes the transport using the stored configuration and performs the handshake again.
+
+```rust
+client.reconnect()?;
+```
 
 ---
 
@@ -204,6 +241,33 @@ match client.next_event()? {
 ### `poll_event(&mut self) -> Result<Option<EventData>>`
 
 Checks for a queued event without blocking. Returns `Ok(None)` if no event is available.
+
+---
+
+## IpcConfig
+
+Protocol-level configuration for connection scanning, retry pacing, payload limits, and handshake version.
+
+```rust
+use presenceforge::IpcConfig;
+
+let config = IpcConfig::fast_connect()
+    .with_max_sockets(3)
+    .with_retry_interval(50)
+    .with_max_payload_size(1024 * 1024);
+```
+
+Common uses:
+
+- `IpcConfig::default()` for standard behavior
+- `IpcConfig::fast_connect()` for quicker local connection attempts
+- `IpcConfig::extended()` for broader scan/retry behavior
+
+Use it with:
+
+- `DiscordIpcClient::new_with_ipc_config(...)`
+- `DiscordIpcClient::new_with_timeout_and_ipc_config(...)`
+- Runtime-specific async clients via their `*_with_ipc_config(...)` constructors
 
 ---
 

--- a/docs/ASYNC_RUNTIMES.md
+++ b/docs/ASYNC_RUNTIMES.md
@@ -1,6 +1,6 @@
 # Async Runtimes Guide
 
-> **Note:** PresenceForge v0.2.0 is an early development release.  
+> **Note:** PresenceForge v0.2.1 is an early development release.  
 > It’s functional, but features may change or be incomplete.
 
 ## Table of Contents
@@ -63,13 +63,13 @@ Add to your `Cargo.toml` with **one** of these feature flags:
 ```toml
 [dependencies]
 # For Tokio
-presenceforge = { version = "0.2.0", features = ["tokio-runtime"] }
+presenceforge = { version = "0.2.1", features = ["tokio-runtime"] }
 
 # For async-std
-presenceforge = { version = "0.2.0", features = ["async-std-runtime"] }
+presenceforge = { version = "0.2.1", features = ["async-std-runtime"] }
 
 # For smol
-presenceforge = { version = "0.2.0", features = ["smol-runtime"] }
+presenceforge = { version = "0.2.1", features = ["smol-runtime"] }
 ```
 
 **This exact code works with all three runtimes:**
@@ -141,7 +141,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-presenceforge = { version = "0.2.0", features = ["tokio-runtime"] }
+presenceforge = { version = "0.2.1", features = ["tokio-runtime"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 
@@ -267,7 +267,7 @@ async fn main() -> Result {
                     let activity = ActivityBuilder::new()
                         .state(state)
                         .details(details)
-                        .start_timestamp_now()
+                        .start_timestamp_now()?
                         .build();
 
                     if let Err(e) = client.set_activity(&activity).await {
@@ -322,7 +322,7 @@ async-std provides an async API similar to the standard library.
 
 ```toml
 [dependencies]
-presenceforge = { version = "0.2.0", features = ["async-std-runtime"] }
+presenceforge = { version = "0.2.1", features = ["async-std-runtime"] }
 async-std = { version = "1", features = ["attributes"] }
 ```
 
@@ -346,7 +346,7 @@ async fn main() -> Result {
     let activity = ActivityBuilder::new()
         .state("Playing async")
         .details("Using async-std")
-        .start_timestamp_now()
+        .start_timestamp_now()?
         .build();
 
     client.set_activity(&activity).await?;
@@ -422,7 +422,7 @@ smol is a small and fast async runtime.
 
 ```toml
 [dependencies]
-presenceforge = { version = "0.2.0", features = ["smol-runtime"] }
+presenceforge = { version = "0.2.1", features = ["smol-runtime"] }
 smol = "2"
 ```
 

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -361,24 +361,27 @@ let mut client = with_retry(&config, || {
 The new reconnectable wrapper provides automatic retry and manual reconnect capabilities:
 
 ```rust
-use presenceforge::async_io::tokio::{TokioDiscordIpcClient, PipeConfig};
-use presenceforge::retry::RetryConfig;
+use presenceforge::ActivityBuilder;
+use presenceforge::async_io::tokio::TokioDiscordIpcClient;
+use presenceforge::retry::{with_retry_async_tokio, RetryConfig};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Create client with reconnect support
-    let mut client = TokioDiscordIpcClient::new(
-        "your_client_id",
-        PipeConfig::Auto,
-        Some(5000)
-    );
-
-    // Connect with retry
     let retry_config = RetryConfig::with_max_attempts(5);
-    client.connect_with_retry(&retry_config).await?;
+    let mut client = with_retry_async_tokio(&retry_config, || {
+        Box::pin(TokioDiscordIpcClient::new_with_timeout(
+            "your_client_id",
+            5000,
+        ))
+    })
+    .await?;
+
+    client.connect().await?;
+
+    let activity = ActivityBuilder::new().state("Retrying").build();
 
     // Later: manual reconnect if connection is lost
-    if let Err(e) = client.set_activity(activity).await {
+    if let Err(e) = client.set_activity(&activity).await {
         if e.is_recoverable() {
             client.reconnect().await?;
         }

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -24,8 +24,8 @@ PresenceForge is a Rust library for integrating Discord Rich Presence into your 
 ### What platforms are supported?
 
 - Linux (standard and Flatpak Discord)
-- macOS (need testing)
-- Windows (needs more testing)
+- macOS
+- Windows
 
 ---
 
@@ -52,11 +52,11 @@ git ls-remote git@github.com:Sreehari425/presenceforge.git
 
 If SSH works but you still have issues, please report them on GitHub Issues.
 
-For now, use version `0.2.0` instead:
+For now, use version `0.2.1` instead:
 
 ```toml
 [dependencies]
-presenceforge = "0.2.0"
+presenceforge = "0.2.1"
 ```
 
 ---
@@ -74,7 +74,7 @@ The feature is called `tokio-runtime`, not `tokio`:
 
 ```toml
 [dependencies]
-presenceforge = { version = "0.2.0", features = ["tokio-runtime"] }
+presenceforge = { version = "0.2.1", features = ["tokio-runtime"] }
 ```
 
 Valid features: `tokio-runtime`, `async-std-runtime`, `smol-runtime`
@@ -94,7 +94,7 @@ Make sure you're using compatible versions:
 
 ```toml
 [dependencies]
-presenceforge = { version = "0.2.0", features = ["tokio-runtime"] }
+presenceforge = { version = "0.2.1", features = ["tokio-runtime"] }
 tokio = { version = "1", features = ["full"] }  # Use version 1.x
 ```
 
@@ -107,7 +107,7 @@ tokio = { version = "1", features = ["full"] }  # Use version 1.x
 **Problem:**
 
 ```rust
-Error: ConnectionFailed("No Discord pipes found")
+Error: NoValidSocket
 ```
 
 **Solutions:**
@@ -312,7 +312,7 @@ ls -l$ XDG_RUNTIME_DIR/discord-ipc-*
 2. **Use convenience method:**
 
    ```rust
-   .start_timestamp_now()  // Automatically uses correct format
+   .start_timestamp_now()?  // Automatically uses correct format
    ```
 
 3. **Check your system time is correct:**

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -2,7 +2,7 @@
 
 Welcome to PresenceForge! This guide will help you get started with integrating Discord Rich Presence into your Rust application.
 
-> **Note:** PresenceForge v0.2.0 is an early development release.  
+> **Note:** PresenceForge v0.2.1 is an early development release.  
 > It’s functional, but features may change or be incomplete.
 
 ## What is Discord Rich Presence?
@@ -36,7 +36,7 @@ Add PresenceForge to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-presenceforge = "0.2.0"
+presenceforge = "0.2.1"
 ```
 
 ### With Async Support
@@ -46,13 +46,13 @@ If you need async support, add one of the runtime features:
 ```toml
 [dependencies]
 # For Tokio users
-presenceforge = { version = "0.2.0", features = ["tokio-runtime"] }
+presenceforge = { version = "0.2.1", features = ["tokio-runtime"] }
 
 # For async-std users
-presenceforge = { version = "0.2.0", features = ["async-std-runtime"] }
+presenceforge = { version = "0.2.1", features = ["async-std-runtime"] }
 
 # For smol users
-presenceforge = { version = "0.2.0", features = ["smol-runtime"] }
+presenceforge = { version = "0.2.1", features = ["smol-runtime"] }
 ```
 
 ## Your First Rich Presence
@@ -70,7 +70,7 @@ cd my-discord-presence
 
 ```toml
 [dependencies]
-presenceforge = "0.2.0"
+presenceforge = "0.2.1"
 ```
 
 ### Step 3: Write your first presence
@@ -139,7 +139,7 @@ assert!(client.is_connected(), "Handshake did not complete");
 let activity = ActivityBuilder::new()
     .state("Hello, Discord!")          // Smaller text line
     .details("Using PresenceForge")    // Larger text line
-    .start_timestamp_now()              // Shows "elapsed" time
+    .start_timestamp_now()?             // Shows "elapsed" time
     .build();
 
 // 4. Send the activity to Discord

--- a/examples/README.md
+++ b/examples/README.md
@@ -42,7 +42,7 @@ cargo run --example basic -- --client-id YOUR_CLIENT_ID
 # Complete Builder Reference - Shows ALL ActivityBuilder options with explanations
 cargo run --example builder_all -- --client-id YOUR_CLIENT_ID
 
-# Basic Flatpak - Simple example for Flatpak Discord with custom path
+# Basic Flatpak - Prefer Flatpak Discord when present, otherwise fall back to standard Discord
 cargo run --example basic_flatpak -- --client-id YOUR_CLIENT_ID
 
 # Game demo - Dynamic game status that changes over time
@@ -74,9 +74,6 @@ cargo run --example async_tokio_reconnect --features tokio-runtime -- --client-i
 
 # Update activity with Tokio - Update state/details without resetting the timer
 cargo run --example update_activity_tokio --features tokio-runtime -- --client-id YOUR_CLIENT_ID
-
-# Flatpak Discord - Connect to Flatpak Discord using custom path configuration
-cargo run --example flatpak_discord -- --client-id YOUR_CLIENT_ID
 
 # Event Listener - Demonstrates IPC Event System (subscribe, unsubscribe, poll_event)
 cargo run --example event_listener -- --client-id YOUR_CLIENT_ID
@@ -119,10 +116,11 @@ Simple Flatpak Discord example showing:
 
 - Discovering Flatpak Discord pipe
 - Connecting using `PipeConfig::CustomPath`
+- Falling back to standard Discord if a Flatpak pipe is not available or usable
 - Same simple structure as `basic.rs` but with custom path configuration
 - Perfect starting point for Flatpak Discord integration
 
-**Note:** If Flatpak Discord is not found, the example will show an error. For automatic fallback, use `basic.rs` with auto-discovery.
+**Note:** This example prefers Flatpak Discord first, then falls back to standard Discord automatically.
 
 ### `game_demo.rs`
 
@@ -201,7 +199,7 @@ Error handling and recovery example (synchronous) showing:
 
 Async error handling with Tokio showing:
 
-- Using `TokioDiscordIpcClient` with reconnect support
+- Using `AsyncDiscordIpcClient` with reconnect support
 - Manual reconnection in async context
 - Automatic retry with `with_retry_async()`
 - Resilient connection loop with exponential backoff
@@ -218,18 +216,6 @@ Activity state updates without timer reset (Tokio async) showing:
 - Shows how to maintain session continuity across state changes
 
 **Key Feature:** The elapsed time on Discord continues uninterrupted when you update the activity while maintaining the original timestamp!
-
-### `flatpak_discord.rs`
-
-Flatpak Discord example showing:
-
-- Discovering Flatpak Discord installations
-- Identifying Flatpak vs standard Discord pipes
-- Connecting using custom path configuration (`PipeConfig::CustomPath`)
-- Setting activity on Flatpak Discord
-- Step-by-step guide with detailed output
-
-**Note:** This example works with both Flatpak and standard Discord. It automatically detects which version is available.
 
 ### `event_listener.rs`
 

--- a/src/async_io/async_std/mod.rs
+++ b/src/async_io/async_std/mod.rs
@@ -8,10 +8,6 @@ use std::io;
 use std::pin::Pin;
 
 #[cfg(unix)]
-use async_std::io::ReadExt as _;
-#[cfg(unix)]
-use async_std::io::WriteExt as _;
-#[cfg(unix)]
 use async_std::os::unix::net::UnixStream;
 
 #[cfg(windows)]
@@ -20,7 +16,8 @@ use async_std::fs::File;
 use crate::async_io::traits::{AsyncRead, AsyncWrite};
 use crate::debug_println;
 use crate::error::{DiscordIpcError, Result};
-use crate::ipc::{constants, PipeConfig};
+use crate::ipc::protocol::IpcConfig;
+use crate::ipc::PipeConfig;
 
 /// A Discord IPC connection using async-std
 pub(crate) enum AsyncStdConnection {
@@ -33,27 +30,45 @@ pub(crate) enum AsyncStdConnection {
 
 impl AsyncStdConnection {
     /// Create a new async-std connection with pipe configuration
+    #[allow(dead_code)]
     pub async fn new_with_config(config: Option<PipeConfig>) -> Result<Self> {
+        Self::new_with_config_and_ipc_config(config, IpcConfig::default()).await
+    }
+
+    /// Create a new async-std connection with pipe and protocol configuration.
+    pub async fn new_with_config_and_ipc_config(
+        config: Option<PipeConfig>,
+        ipc_config: IpcConfig,
+    ) -> Result<Self> {
         let config = config.unwrap_or_default();
 
         #[cfg(unix)]
         {
-            Self::connect_unix_with_config(&config).await
+            Self::connect_unix_with_config(&config, &ipc_config).await
         }
 
         #[cfg(windows)]
         {
-            Self::connect_windows_with_config(&config).await
+            Self::connect_windows_with_config(&config, &ipc_config).await
         }
     }
 
     /// Create a new connection with pipe configuration and timeout
+    #[allow(dead_code)]
     pub async fn new_with_config_and_timeout(
         config: Option<PipeConfig>,
         timeout_ms: u64,
     ) -> Result<Self> {
-        use async_std::future::timeout;
-        use std::time::Duration;
+        Self::new_with_config_timeout_and_ipc_config(config, timeout_ms, IpcConfig::default()).await
+    }
+
+    /// Create a new connection with pipe configuration, timeout, and protocol configuration.
+    pub async fn new_with_config_timeout_and_ipc_config(
+        config: Option<PipeConfig>,
+        timeout_ms: u64,
+        ipc_config: IpcConfig,
+    ) -> Result<Self> {
+        use std::time::{Duration, Instant};
 
         #[cfg(windows)]
         debug_println!(
@@ -67,22 +82,34 @@ impl AsyncStdConnection {
             timeout_ms
         );
 
-        let timeout_duration = Duration::from_millis(timeout_ms);
+        let start = Instant::now();
+        let timeout = Duration::from_millis(timeout_ms);
+        let config = config.unwrap_or_default();
+        let mut last_error_message = None;
 
-        match timeout(timeout_duration, Self::new_with_config(config)).await {
-            Ok(result) => result,
-            Err(_) => Err(DiscordIpcError::ConnectionTimeout {
-                timeout_ms,
-                last_error: None,
-            }),
+        while start.elapsed() < timeout {
+            match Self::new_with_config_and_ipc_config(Some(config.clone()), ipc_config.clone()).await {
+                Ok(connection) => return Ok(connection),
+                Err(DiscordIpcError::NoValidSocket) => {
+                    last_error_message = Some("No valid Discord socket found".to_string());
+                }
+                Err(DiscordIpcError::ConnectionFailed(ref source)) => {
+                    last_error_message = Some(source.to_string());
+                }
+                Err(err) => return Err(err),
+            }
+
+            async_std::task::sleep(Duration::from_millis(ipc_config.retry_interval_ms)).await;
         }
+
+        Err(DiscordIpcError::connection_timeout(timeout_ms, last_error_message))
     }
 
     #[cfg(unix)]
     /// Connect to Discord IPC socket on Unix systems with configuration
-    async fn connect_unix_with_config(config: &PipeConfig) -> Result<Self> {
+    async fn connect_unix_with_config(config: &PipeConfig, ipc_config: &IpcConfig) -> Result<Self> {
         match config {
-            PipeConfig::Auto => Self::connect_unix_auto().await,
+            PipeConfig::Auto => Self::connect_unix_auto(ipc_config).await,
             PipeConfig::CustomPath(path) => UnixStream::connect(path)
                 .await
                 .map(Self::Unix)
@@ -92,10 +119,10 @@ impl AsyncStdConnection {
 
     #[cfg(unix)]
     /// Connect to Discord IPC socket using auto-discovery
-    async fn connect_unix_auto() -> Result<Self> {
+    async fn connect_unix_auto(ipc_config: &IpcConfig) -> Result<Self> {
         let mut last_error = None;
 
-        for socket_path in crate::ipc::discovery::get_socket_paths() {
+        for socket_path in crate::ipc::discovery::get_socket_paths_with_limit(ipc_config.max_sockets) {
             match UnixStream::connect(&socket_path).await {
                 Ok(stream) => {
                     return Ok(Self::Unix(stream));
@@ -125,9 +152,9 @@ impl AsyncStdConnection {
 
     #[cfg(windows)]
     /// Connect to Discord IPC named pipe on Windows with configuration
-    async fn connect_windows_with_config(config: &PipeConfig) -> Result<Self> {
+    async fn connect_windows_with_config(config: &PipeConfig, ipc_config: &IpcConfig) -> Result<Self> {
         match config {
-            PipeConfig::Auto => Self::connect_windows_auto().await,
+            PipeConfig::Auto => Self::connect_windows_auto(ipc_config).await,
             PipeConfig::CustomPath(path) => {
                 use std::fs::OpenOptions;
                 use std::os::windows::fs::OpenOptionsExt;
@@ -151,14 +178,14 @@ impl AsyncStdConnection {
 
     #[cfg(windows)]
     /// Connect to Discord IPC named pipe using auto-discovery
-    async fn connect_windows_auto() -> Result<Self> {
+    async fn connect_windows_auto(ipc_config: &IpcConfig) -> Result<Self> {
         use std::fs::OpenOptions;
         use std::os::windows::fs::OpenOptionsExt;
         const FILE_FLAG_OVERLAPPED: u32 = 0x40000000;
 
         let mut last_error = None;
 
-        for pipe_path in crate::ipc::discovery::get_pipe_paths() {
+        for pipe_path in crate::ipc::discovery::get_pipe_paths_with_limit(ipc_config.max_sockets) {
             debug_println!("Attempting to connect to Windows named pipe: {}", pipe_path);
 
             // Clone pipe_path for the closure
@@ -276,6 +303,7 @@ pub mod client {
     use super::AsyncStdConnection;
     use crate::async_io::client::AsyncDiscordIpcClient;
     use crate::error::{DiscordIpcError, Result};
+    use crate::ipc::protocol::IpcConfig;
     use crate::ipc::PipeConfig;
     use serde_json::Value;
     use std::time::Duration;
@@ -289,6 +317,7 @@ pub mod client {
         client_id: String,
         pipe_config: Option<PipeConfig>,
         timeout_ms: Option<u64>,
+        ipc_config: IpcConfig,
     }
 
     impl AsyncStdDiscordIpcClient {
@@ -297,21 +326,35 @@ pub mod client {
             client_id: impl Into<String>,
             pipe_config: Option<PipeConfig>,
             timeout_ms: Option<u64>,
+            ipc_config: IpcConfig,
         ) -> Result<Self> {
             let client_id = client_id.into();
 
             let connection = if let Some(timeout) = timeout_ms {
-                AsyncStdConnection::new_with_config_and_timeout(pipe_config.clone(), timeout)
-                    .await?
+                AsyncStdConnection::new_with_config_timeout_and_ipc_config(
+                    pipe_config.clone(),
+                    timeout,
+                    ipc_config.clone(),
+                )
+                .await?
             } else {
-                AsyncStdConnection::new_with_config(pipe_config.clone()).await?
+                AsyncStdConnection::new_with_config_and_ipc_config(
+                    pipe_config.clone(),
+                    ipc_config.clone(),
+                )
+                .await?
             };
 
             Ok(Self {
-                inner: AsyncDiscordIpcClient::new(client_id.clone(), connection),
+                inner: AsyncDiscordIpcClient::new_with_ipc_config(
+                    client_id.clone(),
+                    connection,
+                    ipc_config.clone(),
+                ),
                 client_id,
                 pipe_config,
                 timeout_ms,
+                ipc_config,
             })
         }
 
@@ -367,14 +410,26 @@ pub mod client {
         pub async fn reconnect(&mut self) -> Result<Value> {
             // Create a new connection with the same configuration
             let connection = if let Some(timeout) = self.timeout_ms {
-                AsyncStdConnection::new_with_config_and_timeout(self.pipe_config.clone(), timeout)
-                    .await?
+                AsyncStdConnection::new_with_config_timeout_and_ipc_config(
+                    self.pipe_config.clone(),
+                    timeout,
+                    self.ipc_config.clone(),
+                )
+                .await?
             } else {
-                AsyncStdConnection::new_with_config(self.pipe_config.clone()).await?
+                AsyncStdConnection::new_with_config_and_ipc_config(
+                    self.pipe_config.clone(),
+                    self.ipc_config.clone(),
+                )
+                .await?
             };
 
             // Replace the inner client with a new one
-            self.inner = AsyncDiscordIpcClient::new(self.client_id.clone(), connection);
+            self.inner = AsyncDiscordIpcClient::new_with_ipc_config(
+                self.client_id.clone(),
+                connection,
+                self.ipc_config.clone(),
+            );
 
             // Perform handshake
             self.inner.connect().await
@@ -382,7 +437,15 @@ pub mod client {
 
         /// Create a new async-std-based Discord IPC client (uses auto-discovery)
         pub async fn new(client_id: impl Into<String>) -> Result<Self> {
-            Self::new_internal(client_id, None, None).await
+            Self::new_internal(client_id, None, None, IpcConfig::default()).await
+        }
+
+        /// Create a new async-std-based Discord IPC client with custom protocol configuration.
+        pub async fn new_with_ipc_config(
+            client_id: impl Into<String>,
+            ipc_config: IpcConfig,
+        ) -> Result<Self> {
+            Self::new_internal(client_id, None, None, ipc_config).await
         }
 
         /// Create a new async-std-based Discord IPC client with pipe configuration
@@ -390,7 +453,16 @@ pub mod client {
             client_id: impl Into<String>,
             config: Option<PipeConfig>,
         ) -> Result<Self> {
-            Self::new_internal(client_id, config, None).await
+            Self::new_internal(client_id, config, None, IpcConfig::default()).await
+        }
+
+        /// Create a new async-std-based Discord IPC client with pipe and protocol configuration.
+        pub async fn new_with_config_and_ipc_config(
+            client_id: impl Into<String>,
+            config: Option<PipeConfig>,
+            ipc_config: IpcConfig,
+        ) -> Result<Self> {
+            Self::new_internal(client_id, config, None, ipc_config).await
         }
 
         /// Create a new async-std-based Discord IPC client with a connection timeout
@@ -398,7 +470,16 @@ pub mod client {
             client_id: impl Into<String>,
             timeout_ms: u64,
         ) -> Result<Self> {
-            Self::new_internal(client_id, None, Some(timeout_ms)).await
+            Self::new_internal(client_id, None, Some(timeout_ms), IpcConfig::default()).await
+        }
+
+        /// Create a new async-std-based Discord IPC client with timeout and protocol configuration.
+        pub async fn new_with_timeout_and_ipc_config(
+            client_id: impl Into<String>,
+            timeout_ms: u64,
+            ipc_config: IpcConfig,
+        ) -> Result<Self> {
+            Self::new_internal(client_id, None, Some(timeout_ms), ipc_config).await
         }
 
         /// Create a new async-std-based Discord IPC client with pipe configuration and timeout
@@ -407,7 +488,17 @@ pub mod client {
             config: Option<PipeConfig>,
             timeout_ms: u64,
         ) -> Result<Self> {
-            Self::new_internal(client_id, config, Some(timeout_ms)).await
+            Self::new_internal(client_id, config, Some(timeout_ms), IpcConfig::default()).await
+        }
+
+        /// Create a new async-std-based Discord IPC client with pipe configuration, timeout, and protocol configuration.
+        pub async fn new_with_config_timeout_and_ipc_config(
+            client_id: impl Into<String>,
+            config: Option<PipeConfig>,
+            timeout_ms: u64,
+            ipc_config: IpcConfig,
+        ) -> Result<Self> {
+            Self::new_internal(client_id, config, Some(timeout_ms), ipc_config).await
         }
 
         /// Performs handshake with Discord with a timeout

--- a/src/async_io/async_std/mod.rs
+++ b/src/async_io/async_std/mod.rs
@@ -88,7 +88,9 @@ impl AsyncStdConnection {
         let mut last_error_message = None;
 
         while start.elapsed() < timeout {
-            match Self::new_with_config_and_ipc_config(Some(config.clone()), ipc_config.clone()).await {
+            match Self::new_with_config_and_ipc_config(Some(config.clone()), ipc_config.clone())
+                .await
+            {
                 Ok(connection) => return Ok(connection),
                 Err(DiscordIpcError::NoValidSocket) => {
                     last_error_message = Some("No valid Discord socket found".to_string());
@@ -102,7 +104,10 @@ impl AsyncStdConnection {
             async_std::task::sleep(Duration::from_millis(ipc_config.retry_interval_ms)).await;
         }
 
-        Err(DiscordIpcError::connection_timeout(timeout_ms, last_error_message))
+        Err(DiscordIpcError::connection_timeout(
+            timeout_ms,
+            last_error_message,
+        ))
     }
 
     #[cfg(unix)]
@@ -122,7 +127,9 @@ impl AsyncStdConnection {
     async fn connect_unix_auto(ipc_config: &IpcConfig) -> Result<Self> {
         let mut last_error = None;
 
-        for socket_path in crate::ipc::discovery::get_socket_paths_with_limit(ipc_config.max_sockets) {
+        for socket_path in
+            crate::ipc::discovery::get_socket_paths_with_limit(ipc_config.max_sockets)
+        {
             match UnixStream::connect(&socket_path).await {
                 Ok(stream) => {
                     return Ok(Self::Unix(stream));
@@ -152,7 +159,10 @@ impl AsyncStdConnection {
 
     #[cfg(windows)]
     /// Connect to Discord IPC named pipe on Windows with configuration
-    async fn connect_windows_with_config(config: &PipeConfig, ipc_config: &IpcConfig) -> Result<Self> {
+    async fn connect_windows_with_config(
+        config: &PipeConfig,
+        ipc_config: &IpcConfig,
+    ) -> Result<Self> {
         match config {
             PipeConfig::Auto => Self::connect_windows_auto(ipc_config).await,
             PipeConfig::CustomPath(path) => {

--- a/src/async_io/client.rs
+++ b/src/async_io/client.rs
@@ -15,10 +15,11 @@ use super::traits::ipc_utils::read_u32_le;
 use super::traits::{read_exact, write_all, AsyncRead, AsyncWrite};
 use crate::activity::Activity;
 use crate::debug_println;
-use crate::error::{DiscordIpcError, HandshakeFailureKind, InvalidResponseKind, Result};
+use crate::error::{DiscordIpcError, InvalidResponseKind, Result};
 use crate::ipc::{
-    constants, Command, EventData, HandshakePayload, IpcMessage, IpcResponse, Opcode, ReadyEvent,
+    Command, EventData, HandshakePayload, IpcMessage, IpcResponse, Opcode, ReadyEvent,
 };
+use crate::ipc::protocol::{validate_handshake_response, IpcConfig};
 use crate::nonce::generate_nonce;
 
 /// Async implementation of Discord IPC client
@@ -32,6 +33,7 @@ where
     write_buf: BytesMut,
     pending_messages: VecDeque<PendingMessage>,
     connected: bool,
+    ipc_config: IpcConfig,
 }
 
 impl<T> AsyncDiscordIpcClient<T>
@@ -46,6 +48,15 @@ where
     /// This constructor doesn't establish a connection yet.
     /// Call `connect()` to establish a connection.
     pub fn new(client_id: impl Into<String>, connection: T) -> Self {
+        Self::new_with_ipc_config(client_id, connection, IpcConfig::default())
+    }
+
+    /// Creates a new async Discord IPC client with protocol configuration.
+    pub fn new_with_ipc_config(
+        client_id: impl Into<String>,
+        connection: T,
+        ipc_config: IpcConfig,
+    ) -> Self {
         Self {
             connection,
             client_id: client_id.into(),
@@ -53,6 +64,7 @@ where
             write_buf: BytesMut::with_capacity(Self::INITIAL_BUFFER_CAPACITY),
             pending_messages: VecDeque::new(),
             connected: false,
+            ipc_config,
         }
     }
 
@@ -70,7 +82,7 @@ where
         self.connected = false;
 
         let handshake = HandshakePayload {
-            v: constants::IPC_VERSION,
+            v: self.ipc_config.ipc_version,
             client_id: self.client_id.clone(),
         };
 
@@ -81,29 +93,7 @@ where
 
         let (opcode, response) = self.recv_from_connection().await?;
         debug_println!("Handshake response: {}", response);
-
-        // Check for error in the response
-        if let Some(err) = response.get("error") {
-            if let (Some(code), Some(message)) = (
-                err.get("code").and_then(|c| c.as_i64()),
-                err.get("message").and_then(|m| m.as_str()),
-            ) {
-                return Err(DiscordIpcError::discord_error(code as i32, message));
-            } else {
-                return Err(DiscordIpcError::handshake_failed(
-                    HandshakeFailureKind::InvalidErrorPayload,
-                    format!("Invalid error format: {}", err),
-                ));
-            }
-        }
-
-        // Verify opcode is correct for handshake response
-        if !opcode.is_handshake_response() {
-            return Err(DiscordIpcError::handshake_failed(
-                HandshakeFailureKind::UnexpectedOpcode,
-                format!("Expected handshake response opcode, got {:?}", opcode),
-            ));
-        }
+        validate_handshake_response(opcode, &response)?;
 
         self.connected = true;
         Ok(response)
@@ -438,13 +428,13 @@ where
         let length = read_u32_le(&mut self.connection).await?;
 
         // Validate payload size to prevent excessive memory allocation
-        if length > crate::ipc::protocol::constants::MAX_PAYLOAD_SIZE {
+        if length > self.ipc_config.max_payload_size {
             return Err(DiscordIpcError::invalid_response(
                 InvalidResponseKind::PayloadTooLarge,
                 format!(
                     "Payload size {} exceeds maximum allowed size of {} bytes",
                     length,
-                    crate::ipc::protocol::constants::MAX_PAYLOAD_SIZE
+                    self.ipc_config.max_payload_size
                 ),
             ));
         }

--- a/src/async_io/client.rs
+++ b/src/async_io/client.rs
@@ -16,10 +16,10 @@ use super::traits::{read_exact, write_all, AsyncRead, AsyncWrite};
 use crate::activity::Activity;
 use crate::debug_println;
 use crate::error::{DiscordIpcError, InvalidResponseKind, Result};
+use crate::ipc::protocol::{validate_handshake_response, IpcConfig};
 use crate::ipc::{
     Command, EventData, HandshakePayload, IpcMessage, IpcResponse, Opcode, ReadyEvent,
 };
-use crate::ipc::protocol::{validate_handshake_response, IpcConfig};
 use crate::nonce::generate_nonce;
 
 /// Async implementation of Discord IPC client
@@ -433,8 +433,7 @@ where
                 InvalidResponseKind::PayloadTooLarge,
                 format!(
                     "Payload size {} exceeds maximum allowed size of {} bytes",
-                    length,
-                    self.ipc_config.max_payload_size
+                    length, self.ipc_config.max_payload_size
                 ),
             ));
         }

--- a/src/async_io/mod.rs
+++ b/src/async_io/mod.rs
@@ -30,6 +30,7 @@
 //!     let activity = ActivityBuilder::new()
 //!         .state("Playing a game")
 //!         .details("In the menu")
+//!         .start_timestamp_now()?
 //!         .build();
 //!
 //!     client.set_activity(&activity).await?;

--- a/src/async_io/smol/mod.rs
+++ b/src/async_io/smol/mod.rs
@@ -8,8 +8,6 @@ use std::io;
 use std::pin::Pin;
 
 #[cfg(unix)]
-use smol::io::{AsyncReadExt as _, AsyncWriteExt as _};
-#[cfg(unix)]
 use smol::net::unix::UnixStream;
 
 #[cfg(windows)]
@@ -18,7 +16,8 @@ use smol::fs::File;
 use crate::async_io::traits::{AsyncRead, AsyncWrite};
 use crate::debug_println;
 use crate::error::{DiscordIpcError, Result};
-use crate::ipc::{constants, PipeConfig};
+use crate::ipc::protocol::IpcConfig;
+use crate::ipc::PipeConfig;
 
 /// A Discord IPC connection using smol
 pub(crate) enum SmolConnection {
@@ -31,27 +30,45 @@ pub(crate) enum SmolConnection {
 
 impl SmolConnection {
     /// Create a new smol connection with pipe configuration
+    #[allow(dead_code)]
     pub async fn new_with_config(config: Option<PipeConfig>) -> Result<Self> {
+        Self::new_with_config_and_ipc_config(config, IpcConfig::default()).await
+    }
+
+    /// Create a new smol connection with pipe and protocol configuration.
+    pub async fn new_with_config_and_ipc_config(
+        config: Option<PipeConfig>,
+        ipc_config: IpcConfig,
+    ) -> Result<Self> {
         let config = config.unwrap_or_default();
 
         #[cfg(unix)]
         {
-            Self::connect_unix_with_config(&config).await
+            Self::connect_unix_with_config(&config, &ipc_config).await
         }
 
         #[cfg(windows)]
         {
-            Self::connect_windows_with_config(&config).await
+            Self::connect_windows_with_config(&config, &ipc_config).await
         }
     }
 
     /// Create a new connection with pipe configuration and timeout
+    #[allow(dead_code)]
     pub async fn new_with_config_and_timeout(
         config: Option<PipeConfig>,
         timeout_ms: u64,
     ) -> Result<Self> {
-        use smol::Timer;
-        use std::time::Duration;
+        Self::new_with_config_timeout_and_ipc_config(config, timeout_ms, IpcConfig::default()).await
+    }
+
+    /// Create a new connection with pipe configuration, timeout, and protocol configuration.
+    pub async fn new_with_config_timeout_and_ipc_config(
+        config: Option<PipeConfig>,
+        timeout_ms: u64,
+        ipc_config: IpcConfig,
+    ) -> Result<Self> {
+        use std::time::{Duration, Instant};
 
         #[cfg(windows)]
         debug_println!(
@@ -65,31 +82,34 @@ impl SmolConnection {
             timeout_ms
         );
 
-        let timeout_duration = Duration::from_millis(timeout_ms);
+        let start = Instant::now();
+        let timeout = Duration::from_millis(timeout_ms);
+        let config = config.unwrap_or_default();
+        let mut last_error_message = None;
 
-        // Use smol's Timer for timeout
-        match smol::future::or(
-            async {
-                Timer::after(timeout_duration).await;
-                Err(DiscordIpcError::ConnectionTimeout {
-                    timeout_ms,
-                    last_error: None,
-                })
-            },
-            Self::new_with_config(config),
-        )
-        .await
-        {
-            Ok(conn) => Ok(conn),
-            Err(e) => Err(e),
+        while start.elapsed() < timeout {
+            match Self::new_with_config_and_ipc_config(Some(config.clone()), ipc_config.clone()).await {
+                Ok(connection) => return Ok(connection),
+                Err(DiscordIpcError::NoValidSocket) => {
+                    last_error_message = Some("No valid Discord socket found".to_string());
+                }
+                Err(DiscordIpcError::ConnectionFailed(ref source)) => {
+                    last_error_message = Some(source.to_string());
+                }
+                Err(err) => return Err(err),
+            }
+
+            smol::Timer::after(Duration::from_millis(ipc_config.retry_interval_ms)).await;
         }
+
+        Err(DiscordIpcError::connection_timeout(timeout_ms, last_error_message))
     }
 
     #[cfg(unix)]
     /// Connect to Discord IPC socket on Unix systems with configuration
-    async fn connect_unix_with_config(config: &PipeConfig) -> Result<Self> {
+    async fn connect_unix_with_config(config: &PipeConfig, ipc_config: &IpcConfig) -> Result<Self> {
         match config {
-            PipeConfig::Auto => Self::connect_unix_auto().await,
+            PipeConfig::Auto => Self::connect_unix_auto(ipc_config).await,
             PipeConfig::CustomPath(path) => UnixStream::connect(path)
                 .await
                 .map(Self::Unix)
@@ -99,10 +119,10 @@ impl SmolConnection {
 
     #[cfg(unix)]
     /// Connect to Discord IPC socket using auto-discovery
-    async fn connect_unix_auto() -> Result<Self> {
+    async fn connect_unix_auto(ipc_config: &IpcConfig) -> Result<Self> {
         let mut last_error = None;
 
-        for socket_path in crate::ipc::discovery::get_socket_paths() {
+        for socket_path in crate::ipc::discovery::get_socket_paths_with_limit(ipc_config.max_sockets) {
             match UnixStream::connect(&socket_path).await {
                 Ok(stream) => {
                     return Ok(Self::Unix(stream));
@@ -132,9 +152,9 @@ impl SmolConnection {
 
     #[cfg(windows)]
     /// Connect to Discord IPC named pipe on Windows with configuration
-    async fn connect_windows_with_config(config: &PipeConfig) -> Result<Self> {
+    async fn connect_windows_with_config(config: &PipeConfig, ipc_config: &IpcConfig) -> Result<Self> {
         match config {
-            PipeConfig::Auto => Self::connect_windows_auto().await,
+            PipeConfig::Auto => Self::connect_windows_auto(ipc_config).await,
             PipeConfig::CustomPath(path) => {
                 use std::fs::OpenOptions;
                 use std::os::windows::fs::OpenOptionsExt;
@@ -158,14 +178,14 @@ impl SmolConnection {
 
     #[cfg(windows)]
     /// Connect to Discord IPC named pipe using auto-discovery
-    async fn connect_windows_auto() -> Result<Self> {
+    async fn connect_windows_auto(ipc_config: &IpcConfig) -> Result<Self> {
         use std::fs::OpenOptions;
         use std::os::windows::fs::OpenOptionsExt;
         const FILE_FLAG_OVERLAPPED: u32 = 0x40000000;
 
         let mut last_error = None;
 
-        for pipe_path in crate::ipc::discovery::get_pipe_paths() {
+        for pipe_path in crate::ipc::discovery::get_pipe_paths_with_limit(ipc_config.max_sockets) {
             debug_println!("Attempting to connect to Windows named pipe: {}", pipe_path);
 
             // Clone pipe_path for the closure
@@ -281,6 +301,7 @@ pub mod client {
     use super::SmolConnection;
     use crate::async_io::client::AsyncDiscordIpcClient;
     use crate::error::{DiscordIpcError, Result};
+    use crate::ipc::protocol::IpcConfig;
     use crate::ipc::PipeConfig;
     use serde_json::Value;
     use std::time::Duration;
@@ -294,6 +315,7 @@ pub mod client {
         client_id: String,
         pipe_config: Option<PipeConfig>,
         timeout_ms: Option<u64>,
+        ipc_config: IpcConfig,
     }
 
     impl SmolDiscordIpcClient {
@@ -302,20 +324,35 @@ pub mod client {
             client_id: impl Into<String>,
             pipe_config: Option<PipeConfig>,
             timeout_ms: Option<u64>,
+            ipc_config: IpcConfig,
         ) -> Result<Self> {
             let client_id = client_id.into();
 
             let connection = if let Some(timeout) = timeout_ms {
-                SmolConnection::new_with_config_and_timeout(pipe_config.clone(), timeout).await?
+                SmolConnection::new_with_config_timeout_and_ipc_config(
+                    pipe_config.clone(),
+                    timeout,
+                    ipc_config.clone(),
+                )
+                .await?
             } else {
-                SmolConnection::new_with_config(pipe_config.clone()).await?
+                SmolConnection::new_with_config_and_ipc_config(
+                    pipe_config.clone(),
+                    ipc_config.clone(),
+                )
+                .await?
             };
 
             Ok(Self {
-                inner: AsyncDiscordIpcClient::new(client_id.clone(), connection),
+                inner: AsyncDiscordIpcClient::new_with_ipc_config(
+                    client_id.clone(),
+                    connection,
+                    ipc_config.clone(),
+                ),
                 client_id,
                 pipe_config,
                 timeout_ms,
+                ipc_config,
             })
         }
 
@@ -371,14 +408,26 @@ pub mod client {
         pub async fn reconnect(&mut self) -> Result<Value> {
             // Create a new connection with the same configuration
             let connection = if let Some(timeout) = self.timeout_ms {
-                SmolConnection::new_with_config_and_timeout(self.pipe_config.clone(), timeout)
-                    .await?
+                SmolConnection::new_with_config_timeout_and_ipc_config(
+                    self.pipe_config.clone(),
+                    timeout,
+                    self.ipc_config.clone(),
+                )
+                .await?
             } else {
-                SmolConnection::new_with_config(self.pipe_config.clone()).await?
+                SmolConnection::new_with_config_and_ipc_config(
+                    self.pipe_config.clone(),
+                    self.ipc_config.clone(),
+                )
+                .await?
             };
 
             // Replace the inner client with a new one
-            self.inner = AsyncDiscordIpcClient::new(self.client_id.clone(), connection);
+            self.inner = AsyncDiscordIpcClient::new_with_ipc_config(
+                self.client_id.clone(),
+                connection,
+                self.ipc_config.clone(),
+            );
 
             // Perform handshake
             self.inner.connect().await
@@ -386,7 +435,15 @@ pub mod client {
 
         /// Create a new smol-based Discord IPC client (uses auto-discovery)
         pub async fn new(client_id: impl Into<String>) -> Result<Self> {
-            Self::new_internal(client_id, None, None).await
+            Self::new_internal(client_id, None, None, IpcConfig::default()).await
+        }
+
+        /// Create a new smol-based Discord IPC client with custom protocol configuration.
+        pub async fn new_with_ipc_config(
+            client_id: impl Into<String>,
+            ipc_config: IpcConfig,
+        ) -> Result<Self> {
+            Self::new_internal(client_id, None, None, ipc_config).await
         }
 
         /// Create a new smol-based Discord IPC client with pipe configuration
@@ -394,7 +451,16 @@ pub mod client {
             client_id: impl Into<String>,
             config: Option<PipeConfig>,
         ) -> Result<Self> {
-            Self::new_internal(client_id, config, None).await
+            Self::new_internal(client_id, config, None, IpcConfig::default()).await
+        }
+
+        /// Create a new smol-based Discord IPC client with pipe and protocol configuration.
+        pub async fn new_with_config_and_ipc_config(
+            client_id: impl Into<String>,
+            config: Option<PipeConfig>,
+            ipc_config: IpcConfig,
+        ) -> Result<Self> {
+            Self::new_internal(client_id, config, None, ipc_config).await
         }
 
         /// Create a new smol-based Discord IPC client with a connection timeout
@@ -402,7 +468,16 @@ pub mod client {
             client_id: impl Into<String>,
             timeout_ms: u64,
         ) -> Result<Self> {
-            Self::new_internal(client_id, None, Some(timeout_ms)).await
+            Self::new_internal(client_id, None, Some(timeout_ms), IpcConfig::default()).await
+        }
+
+        /// Create a new smol-based Discord IPC client with timeout and protocol configuration.
+        pub async fn new_with_timeout_and_ipc_config(
+            client_id: impl Into<String>,
+            timeout_ms: u64,
+            ipc_config: IpcConfig,
+        ) -> Result<Self> {
+            Self::new_internal(client_id, None, Some(timeout_ms), ipc_config).await
         }
 
         /// Create a new smol-based Discord IPC client with pipe configuration and timeout
@@ -411,7 +486,17 @@ pub mod client {
             config: Option<PipeConfig>,
             timeout_ms: u64,
         ) -> Result<Self> {
-            Self::new_internal(client_id, config, Some(timeout_ms)).await
+            Self::new_internal(client_id, config, Some(timeout_ms), IpcConfig::default()).await
+        }
+
+        /// Create a new smol-based Discord IPC client with pipe configuration, timeout, and protocol configuration.
+        pub async fn new_with_config_timeout_and_ipc_config(
+            client_id: impl Into<String>,
+            config: Option<PipeConfig>,
+            timeout_ms: u64,
+            ipc_config: IpcConfig,
+        ) -> Result<Self> {
+            Self::new_internal(client_id, config, Some(timeout_ms), ipc_config).await
         }
 
         /// Performs handshake with Discord with a timeout

--- a/src/async_io/smol/mod.rs
+++ b/src/async_io/smol/mod.rs
@@ -88,7 +88,9 @@ impl SmolConnection {
         let mut last_error_message = None;
 
         while start.elapsed() < timeout {
-            match Self::new_with_config_and_ipc_config(Some(config.clone()), ipc_config.clone()).await {
+            match Self::new_with_config_and_ipc_config(Some(config.clone()), ipc_config.clone())
+                .await
+            {
                 Ok(connection) => return Ok(connection),
                 Err(DiscordIpcError::NoValidSocket) => {
                     last_error_message = Some("No valid Discord socket found".to_string());
@@ -102,7 +104,10 @@ impl SmolConnection {
             smol::Timer::after(Duration::from_millis(ipc_config.retry_interval_ms)).await;
         }
 
-        Err(DiscordIpcError::connection_timeout(timeout_ms, last_error_message))
+        Err(DiscordIpcError::connection_timeout(
+            timeout_ms,
+            last_error_message,
+        ))
     }
 
     #[cfg(unix)]
@@ -122,7 +127,9 @@ impl SmolConnection {
     async fn connect_unix_auto(ipc_config: &IpcConfig) -> Result<Self> {
         let mut last_error = None;
 
-        for socket_path in crate::ipc::discovery::get_socket_paths_with_limit(ipc_config.max_sockets) {
+        for socket_path in
+            crate::ipc::discovery::get_socket_paths_with_limit(ipc_config.max_sockets)
+        {
             match UnixStream::connect(&socket_path).await {
                 Ok(stream) => {
                     return Ok(Self::Unix(stream));
@@ -152,7 +159,10 @@ impl SmolConnection {
 
     #[cfg(windows)]
     /// Connect to Discord IPC named pipe on Windows with configuration
-    async fn connect_windows_with_config(config: &PipeConfig, ipc_config: &IpcConfig) -> Result<Self> {
+    async fn connect_windows_with_config(
+        config: &PipeConfig,
+        ipc_config: &IpcConfig,
+    ) -> Result<Self> {
         match config {
             PipeConfig::Auto => Self::connect_windows_auto(ipc_config).await,
             PipeConfig::CustomPath(path) => {

--- a/src/async_io/tokio/mod.rs
+++ b/src/async_io/tokio/mod.rs
@@ -3,8 +3,6 @@
 
 //! Tokio-specific implementations for async Discord IPC
 
-#[cfg(windows)]
-use crate::debug_println;
 use std::future::Future;
 use std::io;
 use std::pin::Pin;
@@ -17,7 +15,8 @@ use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeClient};
 
 use crate::async_io::traits::{AsyncRead, AsyncWrite};
 use crate::error::{DiscordIpcError, Result};
-use crate::ipc::{constants, PipeConfig};
+use crate::ipc::protocol::IpcConfig;
+use crate::ipc::{PipeConfig};
 
 /// A Discord IPC connection using Tokio
 pub(crate) enum TokioConnection {
@@ -30,43 +29,74 @@ pub(crate) enum TokioConnection {
 
 impl TokioConnection {
     /// Create a new Tokio connection with pipe configuration
+    #[allow(dead_code)]
     pub async fn new_with_config(config: Option<PipeConfig>) -> Result<Self> {
+        Self::new_with_config_and_ipc_config(config, IpcConfig::default()).await
+    }
+
+    /// Create a new Tokio connection with pipe and protocol configuration.
+    pub async fn new_with_config_and_ipc_config(
+        config: Option<PipeConfig>,
+        ipc_config: IpcConfig,
+    ) -> Result<Self> {
         let config = config.unwrap_or_default();
 
         #[cfg(unix)]
         {
-            Self::connect_unix_with_config(&config).await
+            Self::connect_unix_with_config(&config, &ipc_config).await
         }
 
         #[cfg(windows)]
         {
-            Self::connect_windows_with_config(&config).await
+            Self::connect_windows_with_config(&config, &ipc_config).await
         }
     }
 
     /// Create a new connection with pipe configuration and timeout
+    #[allow(dead_code)]
     pub async fn new_with_config_and_timeout(
         config: Option<PipeConfig>,
         timeout_ms: u64,
     ) -> Result<Self> {
-        use tokio::time::{timeout, Duration};
+        Self::new_with_config_timeout_and_ipc_config(config, timeout_ms, IpcConfig::default()).await
+    }
 
-        let timeout_duration = Duration::from_millis(timeout_ms);
+    /// Create a new connection with pipe configuration, timeout, and protocol configuration.
+    pub async fn new_with_config_timeout_and_ipc_config(
+        config: Option<PipeConfig>,
+        timeout_ms: u64,
+        ipc_config: IpcConfig,
+    ) -> Result<Self> {
+        use tokio::time::{sleep, Duration, Instant};
 
-        match timeout(timeout_duration, Self::new_with_config(config)).await {
-            Ok(result) => result,
-            Err(_) => Err(DiscordIpcError::ConnectionTimeout {
-                timeout_ms,
-                last_error: None,
-            }),
+        let start = Instant::now();
+        let timeout = Duration::from_millis(timeout_ms);
+        let config = config.unwrap_or_default();
+        let mut last_error_message = None;
+
+        while start.elapsed() < timeout {
+            match Self::new_with_config_and_ipc_config(Some(config.clone()), ipc_config.clone()).await {
+                Ok(connection) => return Ok(connection),
+                Err(DiscordIpcError::NoValidSocket) => {
+                    last_error_message = Some("No valid Discord socket found".to_string());
+                }
+                Err(DiscordIpcError::ConnectionFailed(ref source)) => {
+                    last_error_message = Some(source.to_string());
+                }
+                Err(err) => return Err(err),
+            }
+
+            sleep(Duration::from_millis(ipc_config.retry_interval_ms)).await;
         }
+
+        Err(DiscordIpcError::connection_timeout(timeout_ms, last_error_message))
     }
 
     #[cfg(unix)]
     /// Connect to Discord IPC socket on Unix systems with configuration
-    async fn connect_unix_with_config(config: &PipeConfig) -> Result<Self> {
+    async fn connect_unix_with_config(config: &PipeConfig, ipc_config: &IpcConfig) -> Result<Self> {
         match config {
-            PipeConfig::Auto => Self::connect_unix_auto().await,
+            PipeConfig::Auto => Self::connect_unix_auto(ipc_config).await,
             PipeConfig::CustomPath(path) => UnixStream::connect(path)
                 .await
                 .map(Self::Unix)
@@ -76,10 +106,10 @@ impl TokioConnection {
 
     #[cfg(unix)]
     /// Connect to Discord IPC socket using auto-discovery
-    async fn connect_unix_auto() -> Result<Self> {
+    async fn connect_unix_auto(ipc_config: &IpcConfig) -> Result<Self> {
         let mut last_error = None;
 
-        for socket_path in crate::ipc::discovery::get_socket_paths() {
+        for socket_path in crate::ipc::discovery::get_socket_paths_with_limit(ipc_config.max_sockets) {
             match UnixStream::connect(&socket_path).await {
                 Ok(stream) => {
                     return Ok(Self::Unix(stream));
@@ -109,9 +139,9 @@ impl TokioConnection {
 
     #[cfg(windows)]
     /// Connect to Discord IPC named pipe on Windows with configuration
-    async fn connect_windows_with_config(config: &PipeConfig) -> Result<Self> {
+    async fn connect_windows_with_config(config: &PipeConfig, ipc_config: &IpcConfig) -> Result<Self> {
         match config {
-            PipeConfig::Auto => Self::connect_windows_auto().await,
+            PipeConfig::Auto => Self::connect_windows_auto(ipc_config).await,
             PipeConfig::CustomPath(path) => ClientOptions::new()
                 .open(path)
                 .map(Self::Windows)
@@ -121,10 +151,11 @@ impl TokioConnection {
 
     #[cfg(windows)]
     /// Connect to Discord IPC named pipe using auto-discovery
-    async fn connect_windows_auto() -> Result<Self> {
+    async fn connect_windows_auto(ipc_config: &IpcConfig) -> Result<Self> {
+        use crate::debug_println;
         let mut last_error = None;
 
-        for pipe_path in crate::ipc::discovery::get_pipe_paths() {
+        for pipe_path in crate::ipc::discovery::get_pipe_paths_with_limit(ipc_config.max_sockets) {
             // Try to open the named pipe
             debug_println!("Attempting to connect to Windows named pipe: {}", pipe_path);
             match ClientOptions::new().open(pipe_path.clone()) {
@@ -209,6 +240,7 @@ pub mod client {
     use super::TokioConnection;
     use crate::async_io::client::AsyncDiscordIpcClient;
     use crate::error::{DiscordIpcError, Result};
+    use crate::ipc::protocol::IpcConfig;
     use crate::ipc::PipeConfig;
     use serde_json::Value;
     use std::time::Duration;
@@ -216,13 +248,14 @@ pub mod client {
 
     /// A reconnectable Tokio-based Discord IPC client
     ///
-    /// Thiis wrapper stores the connection configuration and client ID,
+    /// This wrapper stores the connection configuration and client ID,
     /// allowing you to reconnect after connection loss.
     pub struct TokioDiscordIpcClient {
         inner: AsyncDiscordIpcClient<TokioConnection>,
         client_id: String,
         pipe_config: Option<PipeConfig>,
         timeout_ms: Option<u64>,
+        ipc_config: IpcConfig,
     }
 
     impl TokioDiscordIpcClient {
@@ -231,20 +264,35 @@ pub mod client {
             client_id: impl Into<String>,
             pipe_config: Option<PipeConfig>,
             timeout_ms: Option<u64>,
+            ipc_config: IpcConfig,
         ) -> Result<Self> {
             let client_id = client_id.into();
 
             let connection = if let Some(timeout) = timeout_ms {
-                TokioConnection::new_with_config_and_timeout(pipe_config.clone(), timeout).await?
+                TokioConnection::new_with_config_timeout_and_ipc_config(
+                    pipe_config.clone(),
+                    timeout,
+                    ipc_config.clone(),
+                )
+                .await?
             } else {
-                TokioConnection::new_with_config(pipe_config.clone()).await?
+                TokioConnection::new_with_config_and_ipc_config(
+                    pipe_config.clone(),
+                    ipc_config.clone(),
+                )
+                .await?
             };
 
             Ok(Self {
-                inner: AsyncDiscordIpcClient::new(client_id.clone(), connection),
+                inner: AsyncDiscordIpcClient::new_with_ipc_config(
+                    client_id.clone(),
+                    connection,
+                    ipc_config.clone(),
+                ),
                 client_id,
                 pipe_config,
                 timeout_ms,
+                ipc_config,
             })
         }
 
@@ -334,14 +382,26 @@ pub mod client {
         pub async fn reconnect(&mut self) -> Result<Value> {
             // Create a new connection with the same configuration
             let connection = if let Some(timeout) = self.timeout_ms {
-                TokioConnection::new_with_config_and_timeout(self.pipe_config.clone(), timeout)
-                    .await?
+                TokioConnection::new_with_config_timeout_and_ipc_config(
+                    self.pipe_config.clone(),
+                    timeout,
+                    self.ipc_config.clone(),
+                )
+                .await?
             } else {
-                TokioConnection::new_with_config(self.pipe_config.clone()).await?
+                TokioConnection::new_with_config_and_ipc_config(
+                    self.pipe_config.clone(),
+                    self.ipc_config.clone(),
+                )
+                .await?
             };
 
             // Replace the inner client with a new one
-            self.inner = AsyncDiscordIpcClient::new(self.client_id.clone(), connection);
+            self.inner = AsyncDiscordIpcClient::new_with_ipc_config(
+                self.client_id.clone(),
+                connection,
+                self.ipc_config.clone(),
+            );
 
             // Perform handshake
             self.inner.connect().await
@@ -349,7 +409,15 @@ pub mod client {
 
         /// Create a new Tokio-based Discord IPC client (uses auto-discovery)
         pub async fn new(client_id: impl Into<String>) -> Result<Self> {
-            Self::new_internal(client_id, None, None).await
+            Self::new_internal(client_id, None, None, IpcConfig::default()).await
+        }
+
+        /// Create a new Tokio-based Discord IPC client with custom protocol configuration.
+        pub async fn new_with_ipc_config(
+            client_id: impl Into<String>,
+            ipc_config: IpcConfig,
+        ) -> Result<Self> {
+            Self::new_internal(client_id, None, None, ipc_config).await
         }
 
         /// Create a new Tokio-based Discord IPC client with pipe configuration
@@ -357,7 +425,16 @@ pub mod client {
             client_id: impl Into<String>,
             config: Option<PipeConfig>,
         ) -> Result<Self> {
-            Self::new_internal(client_id, config, None).await
+            Self::new_internal(client_id, config, None, IpcConfig::default()).await
+        }
+
+        /// Create a new Tokio-based Discord IPC client with pipe and protocol configuration.
+        pub async fn new_with_config_and_ipc_config(
+            client_id: impl Into<String>,
+            config: Option<PipeConfig>,
+            ipc_config: IpcConfig,
+        ) -> Result<Self> {
+            Self::new_internal(client_id, config, None, ipc_config).await
         }
 
         /// Create a new Tokio-based Discord IPC client with a connection timeout
@@ -365,7 +442,16 @@ pub mod client {
             client_id: impl Into<String>,
             timeout_ms: u64,
         ) -> Result<Self> {
-            Self::new_internal(client_id, None, Some(timeout_ms)).await
+            Self::new_internal(client_id, None, Some(timeout_ms), IpcConfig::default()).await
+        }
+
+        /// Create a new Tokio-based Discord IPC client with timeout and protocol configuration.
+        pub async fn new_with_timeout_and_ipc_config(
+            client_id: impl Into<String>,
+            timeout_ms: u64,
+            ipc_config: IpcConfig,
+        ) -> Result<Self> {
+            Self::new_internal(client_id, None, Some(timeout_ms), ipc_config).await
         }
 
         /// Create a new Tokio-based Discord IPC client with pipe configuration and timeout
@@ -374,7 +460,17 @@ pub mod client {
             config: Option<PipeConfig>,
             timeout_ms: u64,
         ) -> Result<Self> {
-            Self::new_internal(client_id, config, Some(timeout_ms)).await
+            Self::new_internal(client_id, config, Some(timeout_ms), IpcConfig::default()).await
+        }
+
+        /// Create a new Tokio-based Discord IPC client with pipe configuration, timeout, and protocol configuration.
+        pub async fn new_with_config_timeout_and_ipc_config(
+            client_id: impl Into<String>,
+            config: Option<PipeConfig>,
+            timeout_ms: u64,
+            ipc_config: IpcConfig,
+        ) -> Result<Self> {
+            Self::new_internal(client_id, config, Some(timeout_ms), ipc_config).await
         }
 
         /// Performs handshake with Discord with a timeout

--- a/src/async_io/tokio/mod.rs
+++ b/src/async_io/tokio/mod.rs
@@ -16,7 +16,7 @@ use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeClient};
 use crate::async_io::traits::{AsyncRead, AsyncWrite};
 use crate::error::{DiscordIpcError, Result};
 use crate::ipc::protocol::IpcConfig;
-use crate::ipc::{PipeConfig};
+use crate::ipc::PipeConfig;
 
 /// A Discord IPC connection using Tokio
 pub(crate) enum TokioConnection {
@@ -75,7 +75,9 @@ impl TokioConnection {
         let mut last_error_message = None;
 
         while start.elapsed() < timeout {
-            match Self::new_with_config_and_ipc_config(Some(config.clone()), ipc_config.clone()).await {
+            match Self::new_with_config_and_ipc_config(Some(config.clone()), ipc_config.clone())
+                .await
+            {
                 Ok(connection) => return Ok(connection),
                 Err(DiscordIpcError::NoValidSocket) => {
                     last_error_message = Some("No valid Discord socket found".to_string());
@@ -89,7 +91,10 @@ impl TokioConnection {
             sleep(Duration::from_millis(ipc_config.retry_interval_ms)).await;
         }
 
-        Err(DiscordIpcError::connection_timeout(timeout_ms, last_error_message))
+        Err(DiscordIpcError::connection_timeout(
+            timeout_ms,
+            last_error_message,
+        ))
     }
 
     #[cfg(unix)]
@@ -109,7 +114,9 @@ impl TokioConnection {
     async fn connect_unix_auto(ipc_config: &IpcConfig) -> Result<Self> {
         let mut last_error = None;
 
-        for socket_path in crate::ipc::discovery::get_socket_paths_with_limit(ipc_config.max_sockets) {
+        for socket_path in
+            crate::ipc::discovery::get_socket_paths_with_limit(ipc_config.max_sockets)
+        {
             match UnixStream::connect(&socket_path).await {
                 Ok(stream) => {
                     return Ok(Self::Unix(stream));
@@ -139,7 +146,10 @@ impl TokioConnection {
 
     #[cfg(windows)]
     /// Connect to Discord IPC named pipe on Windows with configuration
-    async fn connect_windows_with_config(config: &PipeConfig, ipc_config: &IpcConfig) -> Result<Self> {
+    async fn connect_windows_with_config(
+        config: &PipeConfig,
+        ipc_config: &IpcConfig,
+    ) -> Result<Self> {
         match config {
             PipeConfig::Auto => Self::connect_windows_auto(ipc_config).await,
             PipeConfig::CustomPath(path) => ClientOptions::new()

--- a/src/error.rs
+++ b/src/error.rs
@@ -68,6 +68,9 @@ pub enum ErrorCategory {
 pub enum HandshakeFailureKind {
     InvalidErrorPayload,
     UnexpectedOpcode,
+    UnexpectedCommand,
+    UnexpectedEvent,
+    MissingReadyData,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -149,7 +152,7 @@ impl Display for ErrorCategory {
 /// }
 /// ```
 ///
-/// See the `examples/error_handling.rs` file for more comprehensive examples.
+/// See the `examples/connection_retry.rs` file for more comprehensive examples.
 #[derive(Error, Debug)]
 pub enum DiscordIpcError {
     /// Failed to connect to Discord IPC socket or pipe

--- a/src/ipc/connection.rs
+++ b/src/ipc/connection.rs
@@ -164,7 +164,8 @@ impl IpcConnection {
 
         #[cfg(windows)]
         {
-            let (reader, writer) = Self::connect_to_discord_windows_with_config(&config, &ipc_config)?;
+            let (reader, writer) =
+                Self::connect_to_discord_windows_with_config(&config, &ipc_config)?;
             Ok(Self {
                 reader,
                 writer,
@@ -261,7 +262,8 @@ impl IpcConnection {
 
         #[cfg(windows)]
         {
-            let (reader, writer) = Self::connect_to_discord_windows_with_config(config, ipc_config)?;
+            let (reader, writer) =
+                Self::connect_to_discord_windows_with_config(config, ipc_config)?;
             Ok(Self {
                 reader,
                 writer,
@@ -274,7 +276,10 @@ impl IpcConnection {
 
     #[cfg(unix)]
     /// Connect to Discord IPC socket on Unix systems with configuration
-    fn connect_to_discord_unix_with_config(config: &PipeConfig, ipc_config: &IpcConfig) -> Result<UnixStream> {
+    fn connect_to_discord_unix_with_config(
+        config: &PipeConfig,
+        ipc_config: &IpcConfig,
+    ) -> Result<UnixStream> {
         match config {
             PipeConfig::Auto => {
                 // Auto-discovery: try all possible pipes
@@ -466,8 +471,7 @@ impl IpcConnection {
                 ProtocolViolationKind::PayloadTooLarge,
                 format!(
                     "Payload size {} exceeds maximum allowed size of {} bytes",
-                    length,
-                    self.ipc_config.max_payload_size
+                    length, self.ipc_config.max_payload_size
                 ),
                 context,
             ));

--- a/src/ipc/connection.rs
+++ b/src/ipc/connection.rs
@@ -15,7 +15,7 @@ use std::fs::OpenOptions;
 use std::io::{BufReader, BufWriter};
 
 use crate::error::{DiscordIpcError, ProtocolContext, ProtocolViolationKind, Result};
-use crate::ipc::protocol::{constants, Opcode};
+use crate::ipc::protocol::{constants, IpcConfig, Opcode};
 
 /// Configuration for selecting which Discord IPC pipe to connect to
 #[derive(Debug, Clone, Default)]
@@ -47,6 +47,7 @@ pub struct IpcConnection {
     stream: UnixStream,
     read_buf: BytesMut,
     write_buf: BytesMut,
+    ipc_config: IpcConfig,
 }
 
 #[cfg(windows)]
@@ -55,6 +56,7 @@ pub struct IpcConnection {
     writer: BufWriter<std::fs::File>,
     read_buf: BytesMut,
     write_buf: BytesMut,
+    ipc_config: IpcConfig,
 }
 
 impl IpcConnection {
@@ -137,26 +139,38 @@ impl IpcConnection {
     ///
     /// * `config` - Optional pipe configuration. If `None`, auto-discovery is used.
     pub fn new_with_config(config: Option<PipeConfig>) -> Result<Self> {
+        Self::new_with_configs(config, IpcConfig::default())
+    }
+
+    /// Create a new IPC connection with protocol configuration and auto-discovery.
+    pub fn new_with_ipc_config(ipc_config: IpcConfig) -> Result<Self> {
+        Self::new_with_configs(None, ipc_config)
+    }
+
+    /// Create a new IPC connection with pipe and protocol configuration.
+    pub fn new_with_configs(config: Option<PipeConfig>, ipc_config: IpcConfig) -> Result<Self> {
         let config = config.unwrap_or_default();
 
         #[cfg(unix)]
         {
-            let stream = Self::connect_to_discord_unix_with_config(&config)?;
+            let stream = Self::connect_to_discord_unix_with_config(&config, &ipc_config)?;
             Ok(Self {
                 stream,
                 read_buf: BytesMut::with_capacity(Self::INITIAL_BUFFER_CAPACITY),
                 write_buf: BytesMut::with_capacity(Self::INITIAL_BUFFER_CAPACITY),
+                ipc_config,
             })
         }
 
         #[cfg(windows)]
         {
-            let (reader, writer) = Self::connect_to_discord_windows_with_config(&config)?;
+            let (reader, writer) = Self::connect_to_discord_windows_with_config(&config, &ipc_config)?;
             Ok(Self {
                 reader,
                 writer,
                 read_buf: BytesMut::with_capacity(Self::INITIAL_BUFFER_CAPACITY),
                 write_buf: BytesMut::with_capacity(Self::INITIAL_BUFFER_CAPACITY),
+                ipc_config,
             })
         }
     }
@@ -181,6 +195,20 @@ impl IpcConnection {
         config: Option<PipeConfig>,
         timeout_ms: u64,
     ) -> Result<Self> {
+        Self::new_with_configs_and_timeout(config, timeout_ms, IpcConfig::default())
+    }
+
+    /// Create a new IPC connection with protocol configuration and timeout.
+    pub fn new_with_ipc_config_and_timeout(timeout_ms: u64, ipc_config: IpcConfig) -> Result<Self> {
+        Self::new_with_configs_and_timeout(None, timeout_ms, ipc_config)
+    }
+
+    /// Create a new IPC connection with pipe configuration, timeout, and protocol configuration.
+    pub fn new_with_configs_and_timeout(
+        config: Option<PipeConfig>,
+        timeout_ms: u64,
+        ipc_config: IpcConfig,
+    ) -> Result<Self> {
         use std::time::{Duration, Instant};
 
         let start = Instant::now();
@@ -191,18 +219,18 @@ impl IpcConnection {
 
         // Keep trying to connect until we succeed or timeout
         while start.elapsed() < timeout {
-            match Self::try_connect_with_config(&config) {
+            match Self::try_connect_with_config(&config, &ipc_config) {
                 Ok(connection) => return Ok(connection),
                 Err(DiscordIpcError::NoValidSocket) => {
                     last_error_message = Some("No valid Discord socket found".to_string());
                     // Wait a bit before trying again
-                    std::thread::sleep(Duration::from_millis(constants::DEFAULT_RETRY_INTERVAL_MS));
+                    std::thread::sleep(Duration::from_millis(ipc_config.retry_interval_ms));
                     continue;
                 }
                 Err(DiscordIpcError::SocketDiscoveryFailed { ref source, .. }) => {
                     last_error_message = Some(format!("Socket discovery failed: {}", source));
                     // Wait a bit before trying again
-                    std::thread::sleep(Duration::from_millis(constants::DEFAULT_RETRY_INTERVAL_MS));
+                    std::thread::sleep(Duration::from_millis(ipc_config.retry_interval_ms));
                     continue;
                 }
                 Err(e) => {
@@ -219,36 +247,38 @@ impl IpcConnection {
     }
 
     /// Try to connect to Discord with configuration
-    fn try_connect_with_config(config: &PipeConfig) -> Result<Self> {
+    fn try_connect_with_config(config: &PipeConfig, ipc_config: &IpcConfig) -> Result<Self> {
         #[cfg(unix)]
         {
-            let stream = Self::connect_to_discord_unix_with_config(config)?;
+            let stream = Self::connect_to_discord_unix_with_config(config, ipc_config)?;
             Ok(Self {
                 stream,
                 read_buf: BytesMut::with_capacity(Self::INITIAL_BUFFER_CAPACITY),
                 write_buf: BytesMut::with_capacity(Self::INITIAL_BUFFER_CAPACITY),
+                ipc_config: ipc_config.clone(),
             })
         }
 
         #[cfg(windows)]
         {
-            let (reader, writer) = Self::connect_to_discord_windows_with_config(config)?;
+            let (reader, writer) = Self::connect_to_discord_windows_with_config(config, ipc_config)?;
             Ok(Self {
                 reader,
                 writer,
                 read_buf: BytesMut::with_capacity(Self::INITIAL_BUFFER_CAPACITY),
                 write_buf: BytesMut::with_capacity(Self::INITIAL_BUFFER_CAPACITY),
+                ipc_config: ipc_config.clone(),
             })
         }
     }
 
     #[cfg(unix)]
     /// Connect to Discord IPC socket on Unix systems with configuration
-    fn connect_to_discord_unix_with_config(config: &PipeConfig) -> Result<UnixStream> {
+    fn connect_to_discord_unix_with_config(config: &PipeConfig, ipc_config: &IpcConfig) -> Result<UnixStream> {
         match config {
             PipeConfig::Auto => {
                 // Auto-discovery: try all possible pipes
-                Self::connect_to_discord_unix_auto()
+                Self::connect_to_discord_unix_auto(ipc_config)
             }
             PipeConfig::CustomPath(path) => {
                 // Connect to custom path
@@ -264,13 +294,13 @@ impl IpcConnection {
 
     #[cfg(unix)]
     /// Connect to Discord IPC socket using auto-discovery
-    fn connect_to_discord_unix_auto() -> Result<UnixStream> {
+    fn connect_to_discord_unix_auto(ipc_config: &IpcConfig) -> Result<UnixStream> {
         // Try each directory with each socket number
         let mut last_error = None;
         let mut attempted_paths = Vec::new();
 
         for dir in crate::ipc::discovery::candidate_ipc_directories() {
-            for i in 0..constants::MAX_IPC_SOCKETS {
+            for i in 0..ipc_config.max_sockets {
                 let socket_path = format!("{}/{}{}", dir, constants::IPC_SOCKET_PREFIX, i);
                 attempted_paths.push(socket_path.clone());
 
@@ -308,11 +338,12 @@ impl IpcConnection {
     /// Connect to Discord IPC named pipe on Windows with configuration
     fn connect_to_discord_windows_with_config(
         config: &PipeConfig,
+        ipc_config: &IpcConfig,
     ) -> Result<(BufReader<std::fs::File>, BufWriter<std::fs::File>)> {
         match config {
             PipeConfig::Auto => {
                 // Auto-discovery: try all possible pipes
-                Self::connect_to_discord_windows_auto()
+                Self::connect_to_discord_windows_auto(ipc_config)
             }
             PipeConfig::CustomPath(path) => {
                 // Connect to custom path
@@ -332,11 +363,12 @@ impl IpcConnection {
     #[cfg(windows)]
     /// Connect to Discord IPC named pipe on Windows using auto-discovery
     fn connect_to_discord_windows_auto(
+        ipc_config: &IpcConfig,
     ) -> Result<(BufReader<std::fs::File>, BufWriter<std::fs::File>)> {
         let mut last_error = None;
         let mut attempted_paths = Vec::new();
 
-        for path in crate::ipc::discovery::get_pipe_paths() {
+        for path in crate::ipc::discovery::get_pipe_paths_with_limit(ipc_config.max_sockets) {
             attempted_paths.push(path.clone());
 
             // Try to open the named pipe
@@ -428,14 +460,14 @@ impl IpcConnection {
         let length = header_reader.read_u32::<LittleEndian>()?;
 
         // Validate payload size to prevent excessive memory allocation
-        if length > constants::MAX_PAYLOAD_SIZE {
+        if length > self.ipc_config.max_payload_size {
             let context = ProtocolContext::with_payload(opcode_raw, length as usize);
             return Err(DiscordIpcError::protocol_violation(
                 ProtocolViolationKind::PayloadTooLarge,
                 format!(
                     "Payload size {} exceeds maximum allowed size of {} bytes",
                     length,
-                    constants::MAX_PAYLOAD_SIZE
+                    self.ipc_config.max_payload_size
                 ),
                 context,
             ));

--- a/src/ipc/discovery.rs
+++ b/src/ipc/discovery.rs
@@ -80,9 +80,15 @@ pub fn candidate_ipc_directories() -> Vec<String> {
 /// Returns a list of all potential Discord IPC socket/pipe paths to check.
 #[cfg(unix)]
 pub fn get_socket_paths() -> Vec<String> {
+    get_socket_paths_with_limit(constants::MAX_IPC_SOCKETS)
+}
+
+/// Returns a list of all potential Discord IPC socket paths to check with a custom scan limit.
+#[cfg(unix)]
+pub fn get_socket_paths_with_limit(max_sockets: u8) -> Vec<String> {
     let mut paths = Vec::new();
     for dir in candidate_ipc_directories() {
-        for i in 0..constants::MAX_IPC_SOCKETS {
+        for i in 0..max_sockets {
             paths.push(format!("{}/{}{}", dir, constants::IPC_SOCKET_PREFIX, i));
         }
     }
@@ -91,8 +97,14 @@ pub fn get_socket_paths() -> Vec<String> {
 
 #[cfg(windows)]
 pub fn get_pipe_paths() -> Vec<String> {
+    get_pipe_paths_with_limit(constants::MAX_IPC_SOCKETS)
+}
+
+/// Returns a list of all potential Discord IPC pipe paths to check with a custom scan limit.
+#[cfg(windows)]
+pub fn get_pipe_paths_with_limit(max_sockets: u8) -> Vec<String> {
     let mut paths = Vec::new();
-    for i in 0..constants::MAX_IPC_SOCKETS {
+    for i in 0..max_sockets {
         paths.push(format!(r"\\.\pipe\discord-ipc-{}", i));
     }
     paths

--- a/src/ipc/protocol.rs
+++ b/src/ipc/protocol.rs
@@ -571,7 +571,10 @@ mod tests {
         });
 
         let ready = validate_handshake_response(Opcode::Frame, &payload).unwrap();
-        assert_eq!(ready.user.and_then(|u| u.username), Some("tester".to_string()));
+        assert_eq!(
+            ready.user.and_then(|u| u.username),
+            Some("tester".to_string())
+        );
     }
 
     #[test]

--- a/src/ipc/protocol.rs
+++ b/src/ipc/protocol.rs
@@ -1,16 +1,31 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // Copyright (c) 2025-2026 Sreehari Anil and project contributors
 
-use crate::error::{DiscordIpcError, InvalidResponseKind, ProtocolContext, ProtocolViolationKind};
+use crate::error::{
+    DiscordIpcError, HandshakeFailureKind, InvalidResponseKind, ProtocolContext,
+    ProtocolViolationKind,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+
+fn empty_string_as_none<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<String>::deserialize(deserializer)?;
+    Ok(value.and_then(|s| if s.is_empty() { None } else { Some(s) }))
+}
 
 /// Partial user object from Discord READY event payload.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PartialUser {
+    #[serde(default, deserialize_with = "empty_string_as_none")]
     pub id: Option<String>,
+    #[serde(default, deserialize_with = "empty_string_as_none")]
     pub username: Option<String>,
+    #[serde(default, deserialize_with = "empty_string_as_none")]
     pub discriminator: Option<String>,
+    #[serde(default, deserialize_with = "empty_string_as_none")]
     pub avatar: Option<String>,
     pub bot: Option<bool>,
 }
@@ -217,6 +232,81 @@ impl IpcResponse {
             })),
         }
     }
+
+    /// Parse this response as the READY dispatch required to complete the initial handshake.
+    pub fn parse_ready_handshake(self) -> Result<ReadyEvent, DiscordIpcError> {
+        match self.cmd.as_deref() {
+            Some("DISPATCH") => {}
+            Some(other) => {
+                return Err(DiscordIpcError::handshake_failed(
+                    HandshakeFailureKind::UnexpectedCommand,
+                    format!("Expected DISPATCH command in handshake response, got {other}"),
+                ));
+            }
+            None => {
+                return Err(DiscordIpcError::handshake_failed(
+                    HandshakeFailureKind::UnexpectedCommand,
+                    "Handshake response is missing cmd".to_string(),
+                ));
+            }
+        }
+
+        match self.evt.as_deref() {
+            Some("READY") => {}
+            Some(other) => {
+                return Err(DiscordIpcError::handshake_failed(
+                    HandshakeFailureKind::UnexpectedEvent,
+                    format!("Expected READY event in handshake response, got {other}"),
+                ));
+            }
+            None => {
+                return Err(DiscordIpcError::handshake_failed(
+                    HandshakeFailureKind::UnexpectedEvent,
+                    "Handshake response is missing evt".to_string(),
+                ));
+            }
+        }
+
+        let data = self.data.ok_or_else(|| {
+            DiscordIpcError::handshake_failed(
+                HandshakeFailureKind::MissingReadyData,
+                "READY handshake response is missing data".to_string(),
+            )
+        })?;
+
+        serde_json::from_value::<ReadyEvent>(data).map_err(DiscordIpcError::DeserializationFailed)
+    }
+}
+
+/// Validate a handshake response and return the typed READY payload.
+pub fn validate_handshake_response(
+    opcode: Opcode,
+    payload: &Value,
+) -> Result<ReadyEvent, DiscordIpcError> {
+    if let Some(err) = payload.get("error") {
+        if let (Some(code), Some(message)) = (
+            err.get("code").and_then(|c| c.as_i64()),
+            err.get("message").and_then(|m| m.as_str()),
+        ) {
+            return Err(DiscordIpcError::discord_error(code as i32, message));
+        }
+
+        return Err(DiscordIpcError::handshake_failed(
+            HandshakeFailureKind::InvalidErrorPayload,
+            format!("Invalid error format: {}", err),
+        ));
+    }
+
+    if !opcode.is_handshake_response() {
+        return Err(DiscordIpcError::handshake_failed(
+            HandshakeFailureKind::UnexpectedOpcode,
+            format!("Expected handshake response opcode, got {:?}", opcode),
+        ));
+    }
+
+    let response: IpcResponse =
+        serde_json::from_value(payload.clone()).map_err(DiscordIpcError::DeserializationFailed)?;
+    response.parse_ready_handshake()
 }
 
 /// Constants and configuration for Discord IPC protocol
@@ -465,5 +555,40 @@ mod tests {
         } else {
             panic!("Expected Error event");
         }
+    }
+
+    #[test]
+    fn validate_handshake_response_requires_ready_dispatch() {
+        let payload = serde_json::json!({
+            "cmd": "DISPATCH",
+            "evt": "READY",
+            "data": {
+                "user": {
+                    "id": "1234",
+                    "username": "tester"
+                }
+            }
+        });
+
+        let ready = validate_handshake_response(Opcode::Frame, &payload).unwrap();
+        assert_eq!(ready.user.and_then(|u| u.username), Some("tester".to_string()));
+    }
+
+    #[test]
+    fn validate_handshake_response_rejects_non_ready_events() {
+        let payload = serde_json::json!({
+            "cmd": "DISPATCH",
+            "evt": "SOMETHING_ELSE",
+            "data": {}
+        });
+
+        let err = validate_handshake_response(Opcode::Frame, &payload).unwrap_err();
+        assert!(matches!(
+            err,
+            DiscordIpcError::HandshakeFailed {
+                kind: HandshakeFailureKind::UnexpectedEvent,
+                ..
+            }
+        ));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! presenceforge = { version = "0.2.0", features = ["tokio-runtime"] }
+//! presenceforge = { version = "0.2.1", features = ["tokio-runtime"] }
 //! tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 //! ```
 //!
@@ -90,7 +90,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! presenceforge = { version = "0.2.0", features = ["async-std-runtime"] }
+//! presenceforge = { version = "0.2.1", features = ["async-std-runtime"] }
 //! async-std = { version = "1", features = ["attributes"] }
 //! ```
 //!
@@ -125,7 +125,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! presenceforge = { version = "0.2.0", features = ["smol-runtime"] }
+//! presenceforge = { version = "0.2.1", features = ["smol-runtime"] }
 //! smol = "2"
 //! ```
 //!

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -129,7 +129,7 @@ where
 /// # Example
 ///
 /// ```no_run
-/// use presenceforge::async_io::tokio::TokioDiscordIpcClient;
+/// use presenceforge::AsyncDiscordIpcClient;
 /// use presenceforge::retry::{with_retry_async_tokio, RetryConfig};
 ///
 /// # #[tokio::main]
@@ -137,7 +137,7 @@ where
 /// let config = RetryConfig::with_max_attempts(5);
 ///
 /// let mut client = with_retry_async_tokio(&config, || {
-///     Box::pin(async { TokioDiscordIpcClient::new("your-client-id").await })
+///     Box::pin(async { AsyncDiscordIpcClient::new("your-client-id").await })
 /// }).await?;
 /// # Ok(())
 /// # }
@@ -316,14 +316,14 @@ where
 ///
 /// With Tokio:
 /// ```no_run
-/// use presenceforge::async_io::tokio::TokioDiscordIpcClient;
+/// use presenceforge::AsyncDiscordIpcClient;
 /// use presenceforge::retry::{with_retry_async, RetryConfig};
 ///
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), presenceforge::DiscordIpcError> {
 /// let config = RetryConfig::with_max_attempts(5);
 /// let client = with_retry_async(&config, || {
-///     Box::pin(async { TokioDiscordIpcClient::new("your-client-id").await })
+///     Box::pin(async { AsyncDiscordIpcClient::new("your-client-id").await })
 /// }).await?;
 /// # Ok(())
 /// # }

--- a/src/sync/client.rs
+++ b/src/sync/client.rs
@@ -10,11 +10,12 @@ use std::time::{Duration, Instant};
 
 use crate::activity::Activity;
 use crate::debug_println;
-use crate::error::{DiscordIpcError, HandshakeFailureKind, InvalidResponseKind, Result};
+use crate::error::{DiscordIpcError, InvalidResponseKind, Result};
 use crate::ipc::{
-    constants, Command, EventData, HandshakePayload, IpcConnection, IpcMessage, IpcResponse,
-    Opcode, PipeConfig, ReadyEvent,
+    Command, EventData, HandshakePayload, IpcConnection, IpcMessage, IpcResponse, Opcode,
+    PipeConfig, ReadyEvent,
 };
+use crate::ipc::protocol::{validate_handshake_response, IpcConfig};
 use crate::nonce::generate_nonce;
 
 /// Discord IPC Client
@@ -25,12 +26,18 @@ pub struct DiscordIpcClient {
     timeout_ms: Option<u64>,
     pending_messages: VecDeque<PendingMessage>,
     connected: bool,
+    ipc_config: IpcConfig,
 }
 
 impl DiscordIpcClient {
     /// Create a new Discord IPC client (uses auto-discovery)
     pub fn new<S: Into<String>>(client_id: S) -> Result<Self> {
         Self::new_with_config(client_id, None)
+    }
+
+    /// Create a new Discord IPC client using auto-discovery and a custom protocol configuration.
+    pub fn new_with_ipc_config<S: Into<String>>(client_id: S, ipc_config: IpcConfig) -> Result<Self> {
+        Self::new_with_config_and_ipc_config(client_id, None, ipc_config)
     }
 
     /// Create a new Discord IPC client with pipe configuration
@@ -63,8 +70,17 @@ impl DiscordIpcClient {
         client_id: S,
         config: Option<PipeConfig>,
     ) -> Result<Self> {
+        Self::new_with_config_and_ipc_config(client_id, config, IpcConfig::default())
+    }
+
+    /// Create a new Discord IPC client with pipe and protocol configuration.
+    pub fn new_with_config_and_ipc_config<S: Into<String>>(
+        client_id: S,
+        config: Option<PipeConfig>,
+        ipc_config: IpcConfig,
+    ) -> Result<Self> {
         let client_id = client_id.into();
-        let connection = IpcConnection::new_with_config(config.clone())?;
+        let connection = IpcConnection::new_with_configs(config.clone(), ipc_config.clone())?;
 
         Ok(Self {
             client_id,
@@ -73,6 +89,7 @@ impl DiscordIpcClient {
             timeout_ms: None,
             pending_messages: VecDeque::new(),
             connected: false,
+            ipc_config,
         })
     }
 
@@ -92,6 +109,15 @@ impl DiscordIpcClient {
     /// Returns a `DiscordIpcError::ConnectionTimeout` if the connection times out
     pub fn new_with_timeout<S: Into<String>>(client_id: S, timeout_ms: u64) -> Result<Self> {
         Self::new_with_config_and_timeout(client_id, None, timeout_ms)
+    }
+
+    /// Create a new Discord IPC client with a timeout and custom protocol configuration.
+    pub fn new_with_timeout_and_ipc_config<S: Into<String>>(
+        client_id: S,
+        timeout_ms: u64,
+        ipc_config: IpcConfig,
+    ) -> Result<Self> {
+        Self::new_with_config_timeout_and_ipc_config(client_id, None, timeout_ms, ipc_config)
     }
 
     /// Create a new Discord IPC client with pipe configuration and timeout
@@ -123,8 +149,27 @@ impl DiscordIpcClient {
         config: Option<PipeConfig>,
         timeout_ms: u64,
     ) -> Result<Self> {
+        Self::new_with_config_timeout_and_ipc_config(
+            client_id,
+            config,
+            timeout_ms,
+            IpcConfig::default(),
+        )
+    }
+
+    /// Create a new Discord IPC client with pipe configuration, timeout, and protocol configuration.
+    pub fn new_with_config_timeout_and_ipc_config<S: Into<String>>(
+        client_id: S,
+        config: Option<PipeConfig>,
+        timeout_ms: u64,
+        ipc_config: IpcConfig,
+    ) -> Result<Self> {
         let client_id = client_id.into();
-        let connection = IpcConnection::new_with_config_and_timeout(config.clone(), timeout_ms)?;
+        let connection = IpcConnection::new_with_configs_and_timeout(
+            config.clone(),
+            timeout_ms,
+            ipc_config.clone(),
+        )?;
 
         Ok(Self {
             client_id,
@@ -133,6 +178,7 @@ impl DiscordIpcClient {
             timeout_ms: Some(timeout_ms),
             pending_messages: VecDeque::new(),
             connected: false,
+            ipc_config,
         })
     }
 
@@ -150,7 +196,7 @@ impl DiscordIpcClient {
         self.connected = false;
 
         let handshake = HandshakePayload {
-            v: constants::IPC_VERSION,
+            v: self.ipc_config.ipc_version,
             client_id: self.client_id.clone(),
         };
 
@@ -161,29 +207,7 @@ impl DiscordIpcClient {
 
         let (opcode, response) = self.connection.recv()?;
         debug_println!("Handshake response: {}", response);
-
-        // Check for error in the response
-        if let Some(err) = response.get("error") {
-            if let (Some(code), Some(message)) = (
-                err.get("code").and_then(|c| c.as_i64()),
-                err.get("message").and_then(|m| m.as_str()),
-            ) {
-                return Err(DiscordIpcError::discord_error(code as i32, message));
-            } else {
-                return Err(DiscordIpcError::handshake_failed(
-                    HandshakeFailureKind::InvalidErrorPayload,
-                    format!("Invalid error format: {}", err),
-                ));
-            }
-        }
-
-        // Verify opcode is correct for handshake response
-        if !opcode.is_handshake_response() {
-            return Err(DiscordIpcError::handshake_failed(
-                HandshakeFailureKind::UnexpectedOpcode,
-                format!("Expected handshake response opcode, got {:?}", opcode),
-            ));
-        }
+        validate_handshake_response(opcode, &response)?;
 
         self.connected = true;
         Ok(response)
@@ -510,9 +534,13 @@ impl DiscordIpcClient {
 
         // Create a new connection with the same configuration
         self.connection = if let Some(timeout) = self.timeout_ms {
-            IpcConnection::new_with_config_and_timeout(self.pipe_config.clone(), timeout)?
+            IpcConnection::new_with_configs_and_timeout(
+                self.pipe_config.clone(),
+                timeout,
+                self.ipc_config.clone(),
+            )?
         } else {
-            IpcConnection::new_with_config(self.pipe_config.clone())?
+            IpcConnection::new_with_configs(self.pipe_config.clone(), self.ipc_config.clone())?
         };
         self.pending_messages.clear();
         self.connected = false;

--- a/src/sync/client.rs
+++ b/src/sync/client.rs
@@ -11,11 +11,11 @@ use std::time::{Duration, Instant};
 use crate::activity::Activity;
 use crate::debug_println;
 use crate::error::{DiscordIpcError, InvalidResponseKind, Result};
+use crate::ipc::protocol::{validate_handshake_response, IpcConfig};
 use crate::ipc::{
     Command, EventData, HandshakePayload, IpcConnection, IpcMessage, IpcResponse, Opcode,
     PipeConfig, ReadyEvent,
 };
-use crate::ipc::protocol::{validate_handshake_response, IpcConfig};
 use crate::nonce::generate_nonce;
 
 /// Discord IPC Client
@@ -36,7 +36,10 @@ impl DiscordIpcClient {
     }
 
     /// Create a new Discord IPC client using auto-discovery and a custom protocol configuration.
-    pub fn new_with_ipc_config<S: Into<String>>(client_id: S, ipc_config: IpcConfig) -> Result<Self> {
+    pub fn new_with_ipc_config<S: Into<String>>(
+        client_id: S,
+        ipc_config: IpcConfig,
+    ) -> Result<Self> {
         Self::new_with_config_and_ipc_config(client_id, None, ipc_config)
     }
 

--- a/tests/integration_ipc_protocol.rs
+++ b/tests/integration_ipc_protocol.rs
@@ -76,3 +76,23 @@ fn ready_event_is_parsed_from_payload() {
         Some("tester".to_string())
     );
 }
+
+#[test]
+fn ready_event_treats_empty_username_as_none() {
+    let payload = json!({
+        "cmd": "DISPATCH",
+        "evt": "READY",
+        "data": {
+            "user": {
+                "id": "1234",
+                "username": ""
+            }
+        }
+    });
+
+    let ready = DiscordIpcClient::ready_event_from_payload(&payload)
+        .expect("payload should deserialize")
+        .expect("ready event should be present");
+
+    assert_eq!(ready.user.and_then(|u| u.username), None);
+}


### PR DESCRIPTION
closes #11  


#### READY Event User Parsing

- Normalize empty string values in `PartialUser` string fields to `None` during deserialization.
- Prevent `username: ""` from being exposed as `Some("")` in typed READY event payloads.

#### Handshake Validation

- Require a valid `DISPATCH` + `READY` handshake response before marking clients as connected.
- Reject malformed or unexpected handshake frames more defensively in both sync and async clients.

#### IPC Configuration

- Apply `IpcConfig` to live client and transport behavior instead of leaving it as effectively dead configuration.
- Use configured values for handshake IPC version, payload size limits, socket scan count, and retry interval.

### Documentation

- Refresh README, guides, and crate docs to match the current API and examples.
- Correct stale async/runtime examples and reconnect/error-handling snippets.

### Testing

- Added integration coverage for READY payloads where `user.username` is an empty string.
- Added protocol tests for stricter handshake validation.
